### PR TITLE
samtools just quietly decided to change param behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 All changed fall under either one of these types: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`.
 
 ## [Unreleased]
+### Fixed
+- samtools using the correct nr of threads after update to v1.10
 
 ## v0.0.1 - 2020-06-17
 Many minor bug- and quality of life fixes.

--- a/seq2science/rules/alignment.smk
+++ b/seq2science/rules/alignment.smk
@@ -294,7 +294,6 @@ rule samtools_presort:
     benchmark:
         expand("{benchmark_dir}/samtools_presort/{{assembly}}-{{sample}}.benchmark.txt", **config)[0]
     params:
-        threads=lambda wildcards, input, output, threads: max([1, threads - 1]),
         out_dir=f"{config['result_dir']}/{config['aligner']}",
         memory=lambda wildcards, input, output, threads: f"-m {int(1000 * round(config['bam_sort_mem']/threads, 3))}M"
     threads: 2
@@ -308,6 +307,6 @@ rule samtools_presort:
         trap "rm -f {params.out_dir}/{wildcards.assembly}-{wildcards.sample}.tmp*bam" INT;
         rm -f {params.out_dir}/{wildcards.assembly}-{wildcards.sample}.tmp*bam 2> {log}
         
-        samtools sort -@ {params.threads} {params.memory} {input} -o {output} \
+        samtools sort -@ {threads} {params.memory} {input} -o {output} \
         -T {params.out_dir}/{wildcards.assembly}-{wildcards.sample}.tmp 2> {log}
         """

--- a/seq2science/rules/bam_cleaning.smk
+++ b/seq2science/rules/bam_cleaning.smk
@@ -148,7 +148,6 @@ rule samtools_sort:
         expand("{benchmark_dir}/samtools_sort/{{assembly}}-{{sample}}-{{sorting}}.benchmark.txt", **config)[0]
     params:
         sort_order=lambda wildcards: "-n" if wildcards.sorting == 'queryname' else '',
-        threads=lambda wildcards, input, output, threads: max([1, threads - 1]),
         out_dir=f"{config['result_dir']}/{config['aligner']}",
         memory=lambda wildcards, input, output, threads: f"-m {int(1000 * round(config['bam_sort_mem']/threads, 3))}M"
     threads: 2
@@ -162,7 +161,7 @@ rule samtools_sort:
         trap "rm -f {params.out_dir}/{wildcards.assembly}-{wildcards.sample}.tmp*bam" INT;
         rm -f {params.out_dir}/{wildcards.assembly}-{wildcards.sample}.tmp*bam 2> {log}
         
-        samtools sort {params.sort_order} -@ {params.threads} {params.memory} {input} -o {output} \
+        samtools sort {params.sort_order} -@ {threads} {params.memory} {input} -o {output} \
         -T {params.out_dir}/{wildcards.assembly}-{wildcards.sample}.tmp 2> {log}
         """
 


### PR DESCRIPTION
Apparantly samtools changed the behaviour of their `-@` to the total number of threads, where it first was the number of additional threads...

Now samtools uses the correct nr again.