### PR TITLE
only lookup eutils if we do not have local file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 All changed fall under either one of these types: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`.
 
 ## [Unreleased]
-### Fixed
-- bug when specifying 2 cores, which rounded down to zero cores for samtools sorting and crash
 
 ### Fixed
 - seq2science cache on sensible location + seq2science clean fixed
+- bug when specifying 2 cores, which rounded down to zero cores for samtools sorting and crash
+- only lookup sample layout when not local, opens up for slightly better tests in bioconda recipe
 
 ## v0.0.2 - 2020-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ All changed fall under either one of these types: `added`, `changed`, `deprecate
 - bug when specifying 2 cores, which rounded down to zero cores for samtools sorting and crash
 - edger environment was incompatible
 - seq2science cache on sensible location + seq2science clean fixed
-- bug when specifying 2 cores, which rounded down to zero cores for samtools sorting and crash
 - only lookup sample layout when not local, opens up for slightly better tests in bioconda recipe
 
 ## v0.0.2 - 2020-06-29

--- a/docs/content/workflows/chip_seq.md
+++ b/docs/content/workflows/chip_seq.md
@@ -31,6 +31,16 @@ Currently we support two peak callers for the ChIP-seq workflow, MACS2 and genri
 
 For the calculation of peaks MACS2 requires that an "effective" genome size is being passed as one of its arguments. For the more common assemblies (e.g. mm10 and human) these numbers can be found online. However we found googling these numbers quite the hassle, and for lesser studied species these numbers can't be found online. Therefore the pipeline automatically estimates the effective genome size, we calculate this as **the number of unique kmers of the average read length**.
 
+###### Broad peaks
+
+The MACS2 peak caller also supports broad peak calling, and so does seq2science. To let MACS2 call broad peaks you have to add `--broad` to the macs2 command, e.g.:
+
+```
+peak_caller:
+  macs2:
+      --keep-dup 1 --broad
+```
+
 ##### Genrich
 [Genrich](https://github.com/jsh58/Genrich) is a spiritual successor of MACS2, created by [John M. Gaspar](https://github.com/jsh58). Just like MACS2 is generates a '*pileup'*. However the author of genrich realized that the distribution of pileup never follows a poisson distribution. Genrich then uses a [log-normal distribution](https://en.wikipedia.org/wiki/Log-normal_distribution) to model the background. 
 

--- a/docs/resources/Docs_scATAC_seq2science.html
+++ b/docs/resources/Docs_scATAC_seq2science.html
@@ -10,10 +10,6 @@
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 
-<meta name="author" content="Jsmits" />
-
-<meta name="date" content="2020-05-28" />
-
 <title>Seq2science SnapATAC</title>
 
 <script>/*! jQuery v1.11.3 | (c) 2005, 2015 jQuery Foundation, Inc. | jquery.org/license */

--- a/docs/resources/Docs_scATAC_seq2science.html
+++ b/docs/resources/Docs_scATAC_seq2science.html
@@ -360,8 +360,6 @@ summary {
 
 
 <h1 class="title toc-ignore">Seq2science SnapATAC</h1>
-<h4 class="author">Jsmits</h4>
-<h4 class="date">May 28, 2020</h4>
 
 </div>
 

--- a/docs/scripts/Docs_scATAC_seq2science.Rmd
+++ b/docs/scripts/Docs_scATAC_seq2science.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "Seq2science SnapATAC"
-author: "Jsmits"
-date: "May 28, 2020"
 output: html_document
 ---
 

--- a/seq2science/rules/configuration_generic.smk
+++ b/seq2science/rules/configuration_generic.smk
@@ -282,13 +282,12 @@ with FileLock(layout_cachefile_lock):
                 all_samples.append(control)
 
     for sample in all_samples:
-        config['layout'][sample] = eutils_tp.apply_async(get_layout_eutils, (sample,))
         if os.path.exists(expand(f'{{fastq_dir}}/{sample}.{{fqsuffix}}.gz', **config)[0]):
             config['layout'][sample] ='SINGLE'
         elif all(os.path.exists(path) for path in expand(f'{{fastq_dir}}/{sample}_{{fqext}}.{{fqsuffix}}.gz', **config)):
             config['layout'][sample] ='PAIRED'
         elif sample.startswith(('GSM', 'SRR', 'ERR', 'DRR')):
-            # config['layout'][sample] = eutils_tp.apply_async(get_layout_eutils, (sample,))
+            config['layout'][sample] = eutils_tp.apply_async(get_layout_eutils, (sample,))
             trace_layout[sample] = trace_tp.apply_async(get_layout_trace, (sample,))
 
             # sleep 1.25 times the minimum required sleep time so eutils don't complain

--- a/seq2science/rules/configuration_generic.smk
+++ b/seq2science/rules/configuration_generic.smk
@@ -316,7 +316,7 @@ with FileLock(layout_cachefile_lock):
 config['layout'] = {**{key: value for key, value in config['layout'].items() if key in samples.index},
                     **{key: value for key, value in config['layout'].items() if "control" in samples and key in samples["control"].values}}
 
-for sample in samples:
+for sample in samples.index:
     if sample not in config["layout"]:
         raise ValueError(f"The command to lookup sample {sample} online failed!\n"
                          f"Are you sure this sample exists..? Downloading samples with restricted "

--- a/seq2science/rules/configuration_generic.smk
+++ b/seq2science/rules/configuration_generic.smk
@@ -206,10 +206,7 @@ def get_layout_eutils(sample):
                              f"acceptable library layouts are SINGLE-end and PAIRED-end.")
         return layout
     except subprocess.CalledProcessError:
-        raise ValueError(f"The command to lookup sample {sample} online failed!\n"
-                         f"Are you sure this sample exists..? Downloading samples with restricted "
-                         f"access is currently not supported. We advise you to download the sample "
-                         f"manually, and continue the pipeline from there on.")
+        return None
 
 
 def get_layout_trace(sample):
@@ -272,6 +269,7 @@ with FileLock(layout_cachefile_lock):
     eutils_tp = ThreadPool(config.get('ncbi_requests', 3) // 2)
 
     trace_layout = {}
+    eutils_layout = {}
     config['layout'] = {}
 
     # now do a request for each sample that was not in the cache
@@ -287,7 +285,7 @@ with FileLock(layout_cachefile_lock):
         elif all(os.path.exists(path) for path in expand(f'{{fastq_dir}}/{sample}_{{fqext}}.{{fqsuffix}}.gz', **config)):
             config['layout'][sample] ='PAIRED'
         elif sample.startswith(('GSM', 'SRR', 'ERR', 'DRR')):
-            config['layout'][sample] = eutils_tp.apply_async(get_layout_eutils, (sample,))
+            eutils_layout[sample] = eutils_tp.apply_async(get_layout_eutils, (sample,))
             trace_layout[sample] = trace_tp.apply_async(get_layout_trace, (sample,))
 
             # sleep 1.25 times the minimum required sleep time so eutils don't complain
@@ -303,7 +301,8 @@ with FileLock(layout_cachefile_lock):
 
     # now parse the output and store the cache, the local files' layout, and the ones that were fetched online
     config['layout'] = {**layout_cache,
-                        **{k: (v if isinstance(v, str) else v.get()) for k, v in config['layout'].items()},
+                        **{k: v for k, v in config['layout'].items()},
+                        **{k: v.get() for k, v in eutils_layout.items() if v.get() is not None},
                         **{k: v.get() for k, v in trace_layout.items() if v.get() is not None}}
 
     assert all(layout in ['SINGLE', 'PAIRED'] for sample, layout in config['layout'].items())
@@ -316,6 +315,15 @@ with FileLock(layout_cachefile_lock):
 # now only keep the layout of samples that are in samples.tsv
 config['layout'] = {**{key: value for key, value in config['layout'].items() if key in samples.index},
                     **{key: value for key, value in config['layout'].items() if "control" in samples and key in samples["control"].values}}
+
+for sample in samples:
+    if sample not in config["layout"]:
+        raise ValueError(f"The command to lookup sample {sample} online failed!\n"
+                         f"Are you sure this sample exists..? Downloading samples with restricted "
+                         f"access is currently not supported. We advise you to download the sample "
+                         f"manually, and continue the pipeline from there on.")
+
+
 logger.info("Done!\n\n")
 
 # if samples are merged add the layout of the technical replicate to the config


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
Minor stuff. Updated the docs a bit, and only do eutils lookups when we do not have the samples locally. This allows for dryrunning in the bioconda tests, so we can check whether or not all the imports are in the base environment.