### PR TITLE
summit ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 - Profiles no longer overwrite command line arguments
 - Fixed edge-case with condition column in samples but no peak-calling
+- Ambiguity exception with rule narrowpeak_summit
 
 ## [0.2.1] - 2020-08-10
 

--- a/seq2science/rules/peak_counts.smk
+++ b/seq2science/rules/peak_counts.smk
@@ -37,23 +37,24 @@ def get_peakfile_for_summit(wildcards):
     return expand("{result_dir}/{{peak_caller}}/{{assembly}}-{{sample}}_peaks.narrowPeak", **config)
 
 
-if "macs2" not in config.get("peak_caller") or "summits.bed" not in config.get("macs2_types"):
-    rule narrowpeak_summit:
+rule narrowpeak_summit:
+    """
+    Convert a narrowpeak file to a "macs2 summits" file.
+    """
+    input:
+        get_peakfile_for_summit,
+    output:
+        expand("{result_dir}/{{peak_caller}}/{{assembly}}-{{sample}}_summits.bed", **config),
+    log:
+        expand("{log_dir}/narrowpeak_summit/{{sample}}-{{assembly}}-{{peak_caller}}.log", **config),
+    benchmark:
+        expand("{benchmark_dir}/narrowpeak_summit/{{sample}}-{{assembly}}-{{peak_caller}}.benchmark.txt", **config)[0]
+    wildcard_constraints:
+        peak_caller="genrich|hmmratac"  # no macs2
+    shell:
         """
-        Convert a narrowpeak file to a "macs2 summits" file.
+        awk 'BEGIN {{OFS="\t"}} {{ print $1,$2+$10,$2+$10+1,$4,$9; }}' {input} > {output} 2> {log}
         """
-        input:
-            get_peakfile_for_summit,
-        output:
-            expand("{result_dir}/{{peak_caller}}/{{assembly}}-{{sample}}_summits.bed", **config),
-        log:
-            expand("{log_dir}/narrowpeak_summit/{{sample}}-{{assembly}}-{{peak_caller}}.log", **config),
-        benchmark:
-            expand("{benchmark_dir}/narrowpeak_summit/{{sample}}-{{assembly}}-{{peak_caller}}.benchmark.txt", **config)[0]
-        shell:
-            """
-            awk 'BEGIN {{OFS="\t"}} {{ print $1,$2+$10,$2+$10+1,$4,$9; }}' {input} > {output} 2> {log}
-            """
 
 
 def get_summitfiles(wildcards):

--- a/seq2science/rules/peak_counts.smk
+++ b/seq2science/rules/peak_counts.smk
@@ -1,6 +1,3 @@
-ruleorder: macs2_callpeak > narrowpeak_summit
-
-
 def count_table_output():
     """
     get all the count table outputs.
@@ -40,22 +37,23 @@ def get_peakfile_for_summit(wildcards):
     return expand("{result_dir}/{{peak_caller}}/{{assembly}}-{{sample}}_peaks.narrowPeak", **config)
 
 
-rule narrowpeak_summit:
-    """
-    Convert a narrowpeak file to a "macs2 summits" file.
-    """
-    input:
-        get_peakfile_for_summit,
-    output:
-        expand("{result_dir}/{{peak_caller}}/{{assembly}}-{{sample}}_summits.bed", **config),
-    log:
-        expand("{log_dir}/narrowpeak_summit/{{sample}}-{{assembly}}-{{peak_caller}}.log", **config),
-    benchmark:
-        expand("{benchmark_dir}/narrowpeak_summit/{{sample}}-{{assembly}}-{{peak_caller}}.benchmark.txt", **config)[0]
-    shell:
+if "macs2" not in config.get("peak_caller") or "summits.bed" not in config.get("macs2_types"):
+    rule narrowpeak_summit:
         """
-        awk 'BEGIN {{OFS="\t"}} {{ print $1,$2+$10,$2+$10+1,$4,$9; }}' {input} > {output} 2> {log}
+        Convert a narrowpeak file to a "macs2 summits" file.
         """
+        input:
+            get_peakfile_for_summit,
+        output:
+            expand("{result_dir}/{{peak_caller}}/{{assembly}}-{{sample}}_summits.bed", **config),
+        log:
+            expand("{log_dir}/narrowpeak_summit/{{sample}}-{{assembly}}-{{peak_caller}}.log", **config),
+        benchmark:
+            expand("{benchmark_dir}/narrowpeak_summit/{{sample}}-{{assembly}}-{{peak_caller}}.benchmark.txt", **config)[0]
+        shell:
+            """
+            awk 'BEGIN {{OFS="\t"}} {{ print $1,$2+$10,$2+$10+1,$4,$9; }}' {input} > {output} 2> {log}
+            """
 
 
 def get_summitfiles(wildcards):


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
Default atac-seq workflow was giving me ambiguity errors with `rule narrowpeak_summit` and `rule macs2_callpeak`, despite the ruleorder. I think this should fix it?

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
