### PR TITLE
fix unzip everything

### DIFF
--- a/seq2science/rules/get_genome.smk
+++ b/seq2science/rules/get_genome.smk
@@ -137,19 +137,16 @@ rule get_genome_support_files:
         genomepy.Genome(wildcards.assembly, genomes_dir=config["genome_dir"])
 
 
-# NOTE: if the workflow fails it tends to blame this rule.
-# Set "debug: True" in the config to see the root cause.
-if not config.get("debug"):
-    rule unzip_file:
-        """
-        Unzip (b)gzipped files.
-        """
-        input:
-            "{filepath}.gz"
-        output:
-            "{filepath}"
-        wildcard_constraints:
-            filepath=".*(?<!\.gz)$"  # filepath may not end with ".gz"
-        priority: 1
-        run:
-            genomepy.utils.gunzip_and_name(input[0])
+rule unzip_annot:
+    """
+    Unzip (b)gzipped files.
+    """
+    input:
+        "{filepath}.gz"
+    output:
+        "{filepath}"
+    wildcard_constraints:
+        filepath=".*(\.annotation)(\.gtf|\.bed)(?<!\.gz)$"  # filepath may not end with ".gz"
+    priority: 1
+    run:
+        genomepy.utils.gunzip_and_name(input[0])


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
snakemake likes `unzip_file` a little too much. 

**What did change**
replaced with `unzip_annot`, thus rule should only allow annotations to be unzipped.

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [ ] I updated the CHANGELOG
- [ ] These changes are covered by the tests
