### PR TITLE
fix bug merge replicates with condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ## [Unreleased]
 
+### Fixed
+
+- Issue with control and technical replicates
+
 ## [0.2.3] - 2020-09-01
 
 ### Changed

--- a/seq2science/rules/alignment.smk
+++ b/seq2science/rules/alignment.smk
@@ -2,14 +2,9 @@ def get_reads(wildcards):
     """
     Function that returns the reads for any aligner.
     """
-    if "replicate" in samples:
-        if config["layout"].get(wildcards.sample, False) == "SINGLE":
-            return expand("{trimmed_dir}/merged/{{sample}}_trimmed.{fqsuffix}.gz", **config)
-        return sorted(expand("{trimmed_dir}/merged/{{sample}}_{fqext}_trimmed.{fqsuffix}.gz", **config))
-    else:
-        if config["layout"].get(wildcards.sample, False) == "SINGLE":
-            return expand("{trimmed_dir}/{{sample}}_trimmed.{fqsuffix}.gz", **config)
-        return sorted(expand("{trimmed_dir}/{{sample}}_{fqext}_trimmed.{fqsuffix}.gz", **config))
+    if config["layout"].get(wildcards.sample, False) == "SINGLE":
+        return expand("{trimmed_dir}/{{sample}}_trimmed.{fqsuffix}.gz", **config)
+    return sorted(expand("{trimmed_dir}/{{sample}}_{fqext}_trimmed.{fqsuffix}.gz", **config))
 
 
 if config["aligner"] == "bowtie2":

--- a/seq2science/rules/merge_replicates.smk
+++ b/seq2science/rules/merge_replicates.smk
@@ -60,6 +60,8 @@ if "replicate" in samples:
             ],
             **config,
         )
+        if len(input_files["reps"]) == 0:
+            raise ValueError("Something went wrong, and we tried to merge replicates but there were no replicates?!")
         # make sure we make the fastqc report before moving our file
         if get_workflow() != "scatac_seq" and len(input_files["reps"]) == 1 and config["create_qc_report"]:
             input_files["qc"] = expand(
@@ -70,6 +72,8 @@ if "replicate" in samples:
                 **config,
             )
         return input_files
+
+    ruleorder: merge_replicates > renamefastq_PE > sra2fastq_PE
 
     rule merge_replicates:
         """
@@ -83,9 +87,9 @@ if "replicate" in samples:
         input:
             unpack(get_merge_replicates),
         output:
-            temp(sorted(expand("{trimmed_dir}/merged/{{replicate}}{{fqext}}_trimmed.{fqsuffix}.gz", **config))),
+            temp(sorted(expand("{trimmed_dir}/{{replicate}}{{fqext}}_trimmed.{fqsuffix}.gz", **config))),
         wildcard_constraints:
-            replicate=any_given("replicate", "control"),
+            replicate=any_given("replicate"),
             fqext=f"_{config['fqext1']}|_{config['fqext2']}|", # nothing (SE), or fqext with an underscore (PE)
         log:
             expand("{log_dir}/merge_replicates/{{replicate}}{{fqext}}.log", **config),

--- a/seq2science/rules/qc.smk
+++ b/seq2science/rules/qc.smk
@@ -73,10 +73,7 @@ rule featureCounts:
 
 def get_fastqc_input(wildcards):
     if '_trimmed' in wildcards.fname:
-        if 'replicate' in samples and all(sample not in wildcards.fname for sample in samples.index):
-            fqc_input = "{trimmed_dir}/merged/{{fname}}.{fqsuffix}.gz"
-        else:
-            fqc_input = "{trimmed_dir}/{{fname}}.{fqsuffix}.gz"
+        fqc_input = "{trimmed_dir}/{{fname}}.{fqsuffix}.gz"
     else:
         fqc_input = "{fastq_dir}/{{fname}}.{fqsuffix}.gz"
 


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
When working with both control samples and treps, seq2science tries to merge_replicates out of thin air (no input, but output). This PR should solve that. I also removed the unnecessary moving and deleting files around when there are no multiple replicates in a trep.

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
