### PR TITLE
Fasterq dump fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 ### Changed
 
 - testing: clear genomepy caches between runs
+- add parallel-fastq-dump fallback to fasterq-dump
 
 ### Fixed
 

--- a/seq2science/envs/get_fastq.yaml
+++ b/seq2science/envs/get_fastq.yaml
@@ -6,4 +6,4 @@ channels:
 dependencies:
   - pkgs/main::pigz=2.4
   - bioconda::sra-tools=2.10.8
- - bioconda::parallel-fastq-dump=0.6.6
+  - bioconda::parallel-fastq-dump=0.6.6

--- a/seq2science/envs/get_fastq.yaml
+++ b/seq2science/envs/get_fastq.yaml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - pkgs/main::pigz=2.4
   - bioconda::sra-tools=2.10.8
+ - bioconda::parallel-fastq-dump=0.6.6

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -87,7 +87,7 @@ rule sra2fastq_SE:
 
         # dump
         fasterq-dump -s {input}/* -O {output.tmp_fastq} -t {output.tmp_dump} --threads {threads} --split-spot >> {log} 2>&1 || 
-        parallel-fastq-dump -s {input}/* -O $TMPDIR --threads {threads} \
+        parallel-fastq-dump -s {input}/* -O {output.tmp_fastq} --threads {threads} \
         --split-spot --skip-technical --dumpbase --readids --clip --read-filter pass --defline-seq '@$ac.$si.$sg/$ri' --defline-qual '+' >> {log} 2>&1
 
         # rename file and move to output dir
@@ -127,9 +127,8 @@ rule sra2fastq_PE:
 
         # dump
         fasterq-dump -s {input}/* -O {output.tmp_fastq} -t {output.tmp_dump} --threads {threads} --split-3 >> {log} 2>&1 || 
-        parallel-fastq-dump -s {input}/* -O $TMPDIR --threads {threads} \
+        parallel-fastq-dump -s {input}/* -O {output.tmp_fastq} --threads {threads} \
         --split-e --skip-technical --dumpbase --readids --clip --read-filter pass --defline-seq '@$ac.$si.$sg/$ri' --defline-qual '+' >> {log} 2>&1
-
 
         # rename files and move to output dir
         for f in $(ls -1q {output.tmp_fastq} | grep -oP "^[^_]+" | uniq); do

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -131,6 +131,7 @@ rule sra2fastq_PE:
         --split-e --skip-technical --dumpbase --readids --clip --read-filter pass --defline-seq '@$ac.$si.$sg/$ri' --defline-qual '+' >> {log} 2>&1
 
         # rename files and move to output dir
+        shopt -s extglob
         for f in $(ls -1q {output.tmp_fastq} | grep -oP "^[^_]+" | uniq); do
             dst_1={config[fastq_dir]}/{wildcards.sample}_{config[fqext1]}.{config[fqsuffix]}
             dst_2={config[fastq_dir]}/{wildcards.sample}_{config[fqext2]}.{config[fqsuffix]}

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -82,11 +82,13 @@ rule sra2fastq_SE:
         # acquire a lock
         (
             flock --timeout 30 200 || exit 1
-            sleep 2
+            sleep 3
         ) 200>{layout_cachefile_lock}
 
         # dump
-        fasterq-dump -s {input}/* -O {output.tmp_fastq} -t {output.tmp_dump} --threads {threads} --split-spot >> {log} 2>&1
+        fasterq-dump -s {input}/* -O {output.tmp_fastq} -t {output.tmp_dump} --threads {threads} --split-spot >> {log} 2>&1 || 
+        parallel-fastq-dump -s {input}/* -O $TMPDIR --threads {threads} \
+        --split-spot --skip-technical --dumpbase --readids --clip --read-filter pass --defline-seq '@$ac.$si.$sg/$ri' --defline-qual '+' >> {log} 2>&1
 
         # rename file and move to output dir
         for f in $(ls -1q {output.tmp_fastq} | grep -oP "^[^_]+" | uniq); do
@@ -120,11 +122,14 @@ rule sra2fastq_PE:
         # acquire the lock
         (
             flock --timeout 30 200 || exit 1
-            sleep 2
+            sleep 3
         ) 200>{layout_cachefile_lock}
 
         # dump
-        fasterq-dump -s {input}/* -O {output.tmp_fastq} -t {output.tmp_dump} --threads {threads} --split-3 >> {log} 2>&1
+        fasterq-dump -s {input}/* -O {output.tmp_fastq} -t {output.tmp_dump} --threads {threads} --split-3 >> {log} 2>&1 || 
+        parallel-fastq-dump -s {input}/* -O $TMPDIR --threads {threads} \
+        --split-3 --skip-technical --dumpbase --readids --clip --read-filter pass --defline-seq '@$ac.$si.$sg/$ri' --defline-qual '+' >> {log} 2>&1
+
 
         # rename files and move to output dir
         for f in $(ls -1q {output.tmp_fastq} | grep -oP "^[^_]+" | uniq); do

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -128,7 +128,7 @@ rule sra2fastq_PE:
         # dump
         fasterq-dump -s {input}/* -O {output.tmp_fastq} -t {output.tmp_dump} --threads {threads} --split-3 >> {log} 2>&1 || 
         parallel-fastq-dump -s {input}/* -O $TMPDIR --threads {threads} \
-        --split-3 --skip-technical --dumpbase --readids --clip --read-filter pass --defline-seq '@$ac.$si.$sg/$ri' --defline-qual '+' >> {log} 2>&1
+        --split-e --skip-technical --dumpbase --readids --clip --read-filter pass --defline-seq '@$ac.$si.$sg/$ri' --defline-qual '+' >> {log} 2>&1
 
 
         # rename files and move to output dir

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -134,8 +134,8 @@ rule sra2fastq_PE:
         for f in $(ls -1q {output.tmp_fastq} | grep -oP "^[^_]+" | uniq); do
             dst_1={config[fastq_dir]}/{wildcards.sample}_{config[fqext1]}.{config[fqsuffix]}
             dst_2={config[fastq_dir]}/{wildcards.sample}_{config[fqext2]}.{config[fqsuffix]}
-            cat "{output.tmp_fastq}/${{f}}_1.fastq" >> $dst_1
-            cat "{output.tmp_fastq}/${{f}}_2.fastq" >> $dst_2
+            cat "{output.tmp_fastq}/${{f}}_*1.fastq" >> $dst_1
+            cat "{output.tmp_fastq}/${{f}}_*2.fastq" >> $dst_2
         done
         pigz -p {threads} {config[fastq_dir]}/{wildcards.sample}_{config[fqext1]}.{config[fqsuffix]}
         pigz -p {threads} {config[fastq_dir]}/{wildcards.sample}_{config[fqext2]}.{config[fqsuffix]}

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -131,12 +131,11 @@ rule sra2fastq_PE:
         --split-e --skip-technical --dumpbase --readids --clip --read-filter pass --defline-seq '@$ac.$si.$sg/$ri' --defline-qual '+' >> {log} 2>&1
 
         # rename files and move to output dir
-        shopt -s extglob
         for f in $(ls -1q {output.tmp_fastq} | grep -oP "^[^_]+" | uniq); do
             dst_1={config[fastq_dir]}/{wildcards.sample}_{config[fqext1]}.{config[fqsuffix]}
             dst_2={config[fastq_dir]}/{wildcards.sample}_{config[fqext2]}.{config[fqsuffix]}
-            cat "{output.tmp_fastq}/${{f}}_*1.fastq" >> $dst_1
-            cat "{output.tmp_fastq}/${{f}}_*2.fastq" >> $dst_2
+            cat "{output.tmp_fastq}/${{f}}_"*"1.fastq" >> $dst_1
+            cat "{output.tmp_fastq}/${{f}}_"*"2.fastq" >> $dst_2
         done
         pigz -p {threads} {config[fastq_dir]}/{wildcards.sample}_{config[fqext1]}.{config[fqsuffix]}
         pigz -p {threads} {config[fastq_dir]}/{wildcards.sample}_{config[fqext2]}.{config[fqsuffix]}


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
Fasterq-dump is somehow quite unstable for an official tool... I implemented a parallel-fastq-dump fallback in case fasterq-dump fails

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
