### PR TITLE
dont rerun get_genome_annotation

### DIFF
--- a/seq2science/rules/get_genome.smk
+++ b/seq2science/rules/get_genome.smk
@@ -42,7 +42,7 @@ rule get_genome_annotation:
     Download a gene annotation through genomepy.
     """
     input:
-        rules.get_genome.output,
+        ancient(rules.get_genome.output),
     output:
         gtf=expand("{genome_dir}/{{raw_assembly}}/{{raw_assembly}}.annotation.gtf.gz", **config),
         bed=expand("{genome_dir}/{{raw_assembly}}/{{raw_assembly}}.annotation.bed.gz", **config),


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
`get_genome_annotation` was rerunning if the genome was newer, probably causing the issues @quan-xu had!

**What did change**
the age of the genome is no longer taken into account. Sanitizing is performed once, and that should be enough.

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [ ] I updated the CHANGELOG
- [x] These changes are covered by the tests
