### PR TITLE
sra download bug/edge case fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 - bug with edgeR (upperquartile) normalization failed. Not sure why it fails, but when is does, it now returns a dataframe of nan instead of failing the rule, and thus the whole pipeline.
 - use gimmemotifs 0.15.0, so gimme.combine_peaks works with numeric chromosome names
+- edge case with trying to dump sra from empty directory
 
 ## [0.3.0] - 2020-09-22
 

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -11,7 +11,7 @@ rule run2sra:
     falls back on the slower http protocol.
     """
     output:
-        temp(directory(expand("{sra_dir}/{{run}}", **config))),
+        temp(directory(expand("{sra_dir}/{{run}}/{{run}}/{{run}}.sra", **config))),
     log:
         expand("{log_dir}/run2sra/{{run}}.log", **config),
     benchmark:
@@ -74,7 +74,7 @@ rule sra2fastq_SE:
         ) 200>{eutils_cache_lock}
 
         # dump to tmp dir
-        parallel-fastq-dump -s {input}/* -O {output.tmpdir} \
+        parallel-fastq-dump -s {input} -O {output.tmpdir} \
         --threads {threads} --split-spot --skip-technical --dumpbase --readids \
         --clip --read-filter pass --defline-seq '@$ac.$si.$sg/$ri' \
         --defline-qual '+' --gzip >> {log} 2>&1
@@ -115,7 +115,7 @@ rule sra2fastq_PE:
         ) 200>{eutils_cache_lock}
 
         # dump to tmp dir
-        parallel-fastq-dump -s {input}/* -O {output.tmpdir} \
+        parallel-fastq-dump -s {input} -O {output.tmpdir} \
         --threads {threads} --split-e --skip-technical --dumpbase \
         --readids --clip --read-filter pass --defline-seq '@$ac.$si.$sg/$ri' \
         --defline-qual '+' --gzip >> {log} 2>&1

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -19,6 +19,7 @@ rule run2sra:
     message: explain_rule("run2sra")
     resources:
         parallel_downloads=1,
+    params: outdir= lambda wildcards: f"{cofig['sra_dir']}/{wildcards.run}/"
     conda:
         "../envs/get_fastq.yaml"
     wildcard_constraints:
@@ -38,7 +39,7 @@ rule run2sra:
             ) 200>{eutils_cache_lock}
 
             # dump
-            prefetch --max-size 999999999999 --output-directory {output} --log-level debug --progress {wildcards.run} >> {log} 2>&1 && break
+            prefetch --max-size 999999999999 --output-directory {params.outdir} --log-level debug --progress {wildcards.run} >> {log} 2>&1 && break
             sleep 10
         done
         """

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -73,9 +73,6 @@ rule sra2fastq_SE:
             sleep 3
         ) 200>{eutils_cache_lock}
 
-        # setup tmp dir
-        mkdir -p {output.tmpdir}
-
         # dump to tmp dir
         parallel-fastq-dump -s {input}/* -O {output.tmpdir} \
         --threads {threads} --split-spot --skip-technical --dumpbase --readids \
@@ -116,9 +113,6 @@ rule sra2fastq_PE:
             flock --timeout 30 200 || exit 1
             sleep 3
         ) 200>{eutils_cache_lock}
-
-        # setup tmp dir
-        mkdir -p {output.tmpdir}
 
         # dump to tmp dir
         parallel-fastq-dump -s {input}/* -O {output.tmpdir} \


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
Snakemake makes all the parent folders for a file before a rule starts. In case you start a workflow run and download SRA, it starts three download rules, which share a eutils lock. If you then cancel the rule the directory was already made, and s2s assumes the rule exited succesfully..

**What did change**
we use the actual sra as output

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
