### PR TITLE
does this resolve the FileNotFoundErrors?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 - bug with edgeR (upperquartile) normalization failed. Not sure why it fails, but when is does, it now returns a dataframe of nan instead of failing the rule, and thus the whole pipeline.
 - use gimmemotifs 0.15.0, so gimme.combine_peaks works with numeric chromosome names
+- touch a filelock after deleting it, to resolve filenotfounderrors 
 
 ## [0.3.0] - 2020-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 - bug with edgeR (upperquartile) normalization failed. Not sure why it fails, but when is does, it now returns a dataframe of nan instead of failing the rule, and thus the whole pipeline.
 - use gimmemotifs 0.15.0, so gimme.combine_peaks works with numeric chromosome names
-- touch a filelock after deleting it, to resolve filenotfounderrors 
+- s2s is slightly more lenient with an edge-case when running seq2science in parallel  
 
 ## [0.3.0] - 2020-09-22
 

--- a/seq2science/rules/configuration_generic.smk
+++ b/seq2science/rules/configuration_generic.smk
@@ -250,39 +250,44 @@ if "assembly" in samples:
     # determine provider for each new assembly
     providersfile = os.path.expanduser('~/.config/seq2science/providers.p')
     providersfile_lock = os.path.expanduser('~/.config/seq2science/providers.p.lock')
-    prep_filelock(providersfile_lock, 30)
-    with FileLock(providersfile_lock):
-        providers = dict()
-        if os.path.exists(providersfile):
-            providers = pickle.load(open(providersfile, "rb"))
+    for _ in range(2):
+        # we get two tries, in case parallel executions are interfering with one another
+        try:
+            prep_filelock(providersfile_lock, 30)
+            with FileLock(providersfile_lock):
+                providers = dict()
+                if os.path.exists(providersfile):
+                    providers = pickle.load(open(providersfile, "rb"))
 
-        if any([assembly not in providers for assembly in set(samples["assembly"])]):
-            logger.info("Determining assembly providers")
+                if any([assembly not in providers for assembly in set(samples["assembly"])]):
+                    logger.info("Determining assembly providers")
 
-            for assembly in set(samples["assembly"]):
-                if assembly not in providers:
-                    file = os.path.join(config['genome_dir'], assembly, assembly)
-                    providers[assembly] = {"genome": None, "annotation": None}
+                    for assembly in set(samples["assembly"]):
+                        if assembly not in providers:
+                            file = os.path.join(config['genome_dir'], assembly, assembly)
+                            providers[assembly] = {"genome": None, "annotation": None}
 
-                    # check if genome and annotations exist locally
-                    if os.path.exists(f"{file}.fa"):
-                        providers[assembly]["genome"] = "local"
-                    if all(os.path.exists(f) for f in [f"{file}.annotation.gtf", f"{file}.annotation.bed"]):
-                        providers[assembly]["annotation"] = "local"
+                            # check if genome and annotations exist locally
+                            if os.path.exists(f"{file}.fa"):
+                                providers[assembly]["genome"] = "local"
+                            if all(os.path.exists(f) for f in [f"{file}.annotation.gtf", f"{file}.annotation.bed"]):
+                                providers[assembly]["annotation"] = "local"
 
-                    # check if the annotation can be downloaded
-                    if providers[assembly]["annotation"] is None:
-                        annotion_provider = provider_with_file("annotation", assembly)
-                        if annotion_provider:
-                            providers[assembly]["genome"] = annotion_provider  # exists if annotation does
-                            providers[assembly]["annotation"] = annotion_provider
+                            # check if the annotation can be downloaded
+                            if providers[assembly]["annotation"] is None:
+                                annotion_provider = provider_with_file("annotation", assembly)
+                                if annotion_provider:
+                                    providers[assembly]["genome"] = annotion_provider  # exists if annotation does
+                                    providers[assembly]["annotation"] = annotion_provider
 
-                    # check if the genome can be downloaded
-                    if providers[assembly]["genome"] is None:
-                        genome_provider = provider_with_file("genome", assembly)
-                        providers[assembly]["genome"] = genome_provider
+                            # check if the genome can be downloaded
+                            if providers[assembly]["genome"] is None:
+                                genome_provider = provider_with_file("genome", assembly)
+                                providers[assembly]["genome"] = genome_provider
 
-            pickle.dump(providers, open(providersfile, "wb"))
+                    pickle.dump(providers, open(providersfile, "wb"))
+        except FileNotFoundError:
+            continue
 
     # check the providers for the required assemblies
     annotation_required = "rna_seq" in get_workflow() or config["aligner"] == "star"
@@ -342,21 +347,26 @@ if "control" in samples:
 
 eutils_cache = os.path.expanduser('~/.config/seq2science/eutils.p')
 eutils_cache_lock = os.path.expanduser('~/.config/seq2science/eutils.p.lock')
-prep_filelock(eutils_cache_lock, 30)
-with FileLock(eutils_cache_lock):
+for _ in range(2):
+    # we get two tries, in case parallel executions are interfering with one another
     try:
-        sampledict = pickle.load(open(eutils_cache, "rb"))
+        prep_filelock(eutils_cache_lock, 30)
+        with FileLock(eutils_cache_lock):
+            try:
+                sampledict = pickle.load(open(eutils_cache, "rb"))
+            except FileNotFoundError:
+                sampledict = {}
+
+            missing_samples = [sample for sample in all_samples if sample not in sampledict.keys()]
+            if len(missing_samples) > 0:
+                sampledict.update(samples2metadata(missing_samples, config))
+
+            pickle.dump(sampledict, open(eutils_cache, "wb"))
+
+            # only keep samples for this run
+            sampledict = {sample: values for sample, values in sampledict.items() if sample in all_samples}
     except FileNotFoundError:
-        sampledict = {}
-
-    missing_samples = [sample for sample in all_samples if sample not in sampledict.keys()]
-    if len(missing_samples) > 0:
-        sampledict.update(samples2metadata(missing_samples, config))
-
-    pickle.dump(sampledict, open(eutils_cache, "wb"))
-
-    # only keep samples for this run
-    sampledict = {sample: values for sample, values in sampledict.items() if sample in all_samples}
+        continue
 
 logger.info("Done!\n\n")
 
@@ -464,25 +474,29 @@ else:
 if config.get("create_trackhub"):
     hubfile = os.path.expanduser('~/.config/seq2science/ucsc_trackhubs.p')
     hubfile_lock = os.path.expanduser('~/.config/seq2science/ucsc_trackhubs.p.lock')
-    prep_filelock(hubfile_lock)
+    for _ in range(2):
+        # we get two tries, in case parallel executions are interfering with one another
+        try:
+            prep_filelock(hubfile_lock)
+            with FileLock(hubfile_lock):
+                if not os.path.exists(hubfile):
+                    # check for response of ucsc
+                    response = requests.get(f"https://genome.ucsc.edu/cgi-bin/hgGateway",
+                                            allow_redirects=True)
+                    assert response.ok, "Make sure you are connected to the internet"
 
-    with FileLock(hubfile_lock):
-        if not os.path.exists(hubfile):
-            # check for response of ucsc
-            response = requests.get(f"https://genome.ucsc.edu/cgi-bin/hgGateway",
-                                    allow_redirects=True)
-            assert response.ok, "Make sure you are connected to the internet"
+                    with urllib.request.urlopen("https://api.genome.ucsc.edu/list/ucscGenomes") as url:
+                        data = json.loads(url.read().decode())['ucscGenomes']
 
-            with urllib.request.urlopen("https://api.genome.ucsc.edu/list/ucscGenomes") as url:
-                data = json.loads(url.read().decode())['ucscGenomes']
+                    # generate a dict ucsc assemblies
+                    ucsc_assemblies = dict()
+                    for key, values in data.items():
+                        ucsc_assemblies[key.lower()] = [key, values.get("description", "")]
 
-            # generate a dict ucsc assemblies
-            ucsc_assemblies = dict()
-            for key, values in data.items():
-                ucsc_assemblies[key.lower()] = [key, values.get("description", "")]
+                    # save to file
+                    pickle.dump(ucsc_assemblies, open(hubfile, "wb"))
 
-            # save to file
-            pickle.dump(ucsc_assemblies, open(hubfile, "wb"))
-
-        # read hubfile
-        ucsc_assemblies = pickle.load(open(hubfile, "rb"))
+                # read hubfile
+                ucsc_assemblies = pickle.load(open(hubfile, "rb"))
+        except FileNotFoundError:
+            continue

--- a/seq2science/rules/configuration_generic.smk
+++ b/seq2science/rules/configuration_generic.smk
@@ -360,7 +360,7 @@ for _ in range(2):
 
             missing_samples = [sample for sample in all_samples if sample not in sampledict.keys()]
             if len(missing_samples) > 0:
-                sampledict.update(samples2metadata(missing_samples, config))
+                sampledict.update(samples2metadata(missing_samples, config, logger))
 
             pickle.dump(sampledict, open(pysradb_cache, "wb"))
 

--- a/seq2science/rules/configuration_generic.smk
+++ b/seq2science/rules/configuration_generic.smk
@@ -351,10 +351,10 @@ pysradb_cache_lock = os.path.expanduser(f'~/.config/seq2science/{seq2science.__v
 for _ in range(2):
     # we get two tries, in case parallel executions are interfering with one another
     try:
-        prep_filelock(eutils_cache_lock, 30)
-        with FileLock(eutils_cache_lock):
+        prep_filelock(pysradb_cache_lock, 30)
+        with FileLock(pysradb_cache_lock):
             try:
-                sampledict = pickle.load(open(eutils_cache, "rb"))
+                sampledict = pickle.load(open(pysradb_cache, "rb"))
             except FileNotFoundError:
                 sampledict = {}
 
@@ -362,7 +362,7 @@ for _ in range(2):
             if len(missing_samples) > 0:
                 sampledict.update(samples2metadata(missing_samples, config))
 
-            pickle.dump(sampledict, open(eutils_cache, "wb"))
+            pickle.dump(sampledict, open(pysradb_cache, "wb"))
 
             # only keep samples for this run
             sampledict = {sample: values for sample, values in sampledict.items() if sample in all_samples}

--- a/seq2science/rules/configuration_generic.smk
+++ b/seq2science/rules/configuration_generic.smk
@@ -287,8 +287,12 @@ if "assembly" in samples:
                                 providers[assembly]["genome"] = genome_provider
 
                     pickle.dump(providers, open(providersfile, "wb"))
+                break
         except FileNotFoundError:
-            continue
+            time.sleep(1)
+    else:
+        logger.error("There were some problems with locking the seq2science cache. Please try again in a bit.")
+        raise TerminatedException
 
     # check the providers for the required assemblies
     annotation_required = "rna_seq" in get_workflow() or config["aligner"] == "star"
@@ -366,8 +370,12 @@ for _ in range(2):
 
             # only keep samples for this run
             sampledict = {sample: values for sample, values in sampledict.items() if sample in all_samples}
+        break
     except FileNotFoundError:
-        continue
+        time.sleep(1)
+else:
+    logger.error("There were some problems with locking the seq2science cache. Please try again in a bit.")
+    raise TerminatedException
 
 logger.info("Done!\n\n")
 
@@ -515,5 +523,10 @@ if config.get("create_trackhub"):
 
                 # read hubfile
                 ucsc_assemblies = pickle.load(open(hubfile, "rb"))
+            break
         except FileNotFoundError:
-            continue
+            time.sleep(1)
+    else:
+        logger.error("There were some problems with locking the seq2science cache. Please try again in a bit.")
+        raise TerminatedException
+

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -6,7 +6,6 @@ import sys
 from typing import List
 import time
 import urllib.request
-from pathlib import Path
 
 import pandas as pd
 import pysradb
@@ -163,7 +162,6 @@ def prep_filelock(lock_file, max_age=10):
         if os.path.exists(lock_file) and \
                 time.time() - os.stat(lock_file).st_mtime > max_age:
             os.unlink(lock_file)
-            Path(lock_file).touch()
     except FileNotFoundError:
          pass
 

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -6,6 +6,7 @@ import sys
 from typing import List
 import time
 import urllib.request
+from pathlib import Path
 
 import pandas as pd
 import pysradb
@@ -162,6 +163,7 @@ def prep_filelock(lock_file, max_age=10):
         if os.path.exists(lock_file) and \
                 time.time() - os.stat(lock_file).st_mtime > max_age:
             os.unlink(lock_file)
+            Path(lock_file).touch()
     except FileNotFoundError:
          pass
 


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
Sometimes the tests fail on the filelock:

```
FileNotFoundError in line 346 of /var/lib/jenkins/workspace/seq2science_develop/miniconda/envs/s2s/lib/python3.6/site-packages/seq2science/rules/configuration_generic.smk:
[Errno 2] No such file or directory: '/var/lib/jenkins/.config/seq2science/eutils.p.lock'
  File "/var/lib/jenkins/workspace/seq2science_develop/miniconda/envs/s2s/lib/python3.6/site-packages/seq2science/workflows/alignment/Snakefile", line 4, in <module>
  File "/var/lib/jenkins/workspace/seq2science_develop/miniconda/envs/s2s/lib/python3.6/site-packages/seq2science/rules/configuration.smk", line 1, in <module>
  File "/var/lib/jenkins/workspace/seq2science_develop/miniconda/envs/s2s/lib/python3.6/site-packages/seq2science/rules/configuration_generic.smk", line 346, in <module>
  File "/var/lib/jenkins/workspace/seq2science_develop/miniconda/envs/s2s/lib/python3.6/site-packages/filelock.py", line 323, in __enter__
  File "/var/lib/jenkins/workspace/seq2science_develop/miniconda/envs/s2s/lib/python3.6/site-packages/filelock.py", line 271, in acquire
  File "/var/lib/jenkins/workspace/seq2science_develop/miniconda/envs/s2s/lib/python3.6/site-packages/filelock.py", line 384, in _acquire
```

**What did change**
We make the lock after deleting it. This shouldn't really be necessary I think since we never made the lock beforehand I believe. But this should resolve the file not found error:

https://github.com/benediktschmitt/py-filelock/blob/master/filelock.py#L384


**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
