### PR TITLE
stop trying when file exists locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - now give a nice error message when a technical replicate consists of a mix of paired-end and single-end samples
 - issue with large number of inputs for multiqc exceeding the os command max length
 - bug with downloading only SRR/DRR samples (but no GSM)
-- issue with async generation of genome support files 
+- issue with async generation of genome support files
+- checking for sequencing runs when sample is already downloaded 
 
 ## [0.3.0] - 2020-09-22
 

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -239,7 +239,7 @@ rule runs2sample:
     benchmark:
         expand("{benchmark_dir}/run2sample/{{sample}}{{suffix}}.benchmark.txt", **config)[0]
     wildcard_constraints:
-        sample=lambda wildcards: "(GSM|SRR|ERR|DRR)\d+" if "runs" in sampledict[wildcards.sample] else "$a",
+        sample="|".join([sample for sample, values in sampledict.items() if "run" in values])
     run:
         shell("cp {input[0]} {output}")
 

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -239,7 +239,7 @@ rule runs2sample:
     benchmark:
         expand("{benchmark_dir}/run2sample/{{sample}}{{suffix}}.benchmark.txt", **config)[0]
     wildcard_constraints:
-        sample="(GSM|SRR|ERR|DRR)\d+",
+        sample=lambda wildcards: "(GSM|SRR|ERR|DRR)\d+" if "runs" in sampledict[wildcards.sample] else "$a",
     run:
         shell("cp {input[0]} {output}")
 

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -226,6 +226,8 @@ def get_runs_from_sample(wildcards):
     return run_fastqs
 
 
+public_samples = [sample for sample, values in sampledict.items() if "runs" in values]
+
 rule runs2sample:
     """
     Concatenate a single run or multiple runs together into a fastq
@@ -239,7 +241,7 @@ rule runs2sample:
     benchmark:
         expand("{benchmark_dir}/run2sample/{{sample}}{{suffix}}.benchmark.txt", **config)[0]
     wildcard_constraints:
-        sample="|".join([sample for sample, values in sampledict.items() if "run" in values])
+        sample="|".join(public_samples) if len(public_samples) > 0 else "$a"
     run:
         shell("cp {input[0]} {output}")
 


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
When a GSM exists in the `fastq_dir`, `rule runs2sample` still tries to check `sampledict[wildcards.sample]["runs"]`. However, "runs" does not exist in this case.

**What did change**
prevented runs2sample from running its inputfunction when "runs" is not found in the sampledict.

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
