### PR TITLE
Sc rna kb 10x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ### Added
 
+- (BETA) Added support for multiple scrna-seq platforms (Kallistobus)
+- (BETA) Fastp detects the correct mate for trimming based on BUS settings.
+- (BETA) Support for Kallistobus short-hand syntax.
 - (BETA) new scrna-seq workflow! Currently only supports celseq protocols.
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - (BETA) Added support for multiple scrna-seq platforms (Kallistobus)
 - (BETA) Fastp detects the correct mate for trimming based on BUS settings.
 - (BETA) Support for Kallistobus short-hand syntax.
-- (BETA) new scrna-seq workflow! Currently only supports celseq protocols.
-
 
 ### Changed
 

--- a/seq2science/rules/qc.smk
+++ b/seq2science/rules/qc.smk
@@ -1,7 +1,7 @@
 import re
 
 import seq2science
-from seq2science.util import sieve_bam
+from seq2science.util import sieve_bam, get_bustools_rid
 
 
 def samtools_stats_input(wildcards):
@@ -632,11 +632,7 @@ def get_trimming_qc(sample):
             # single-cell RNA seq does weird things with barcodes in the fastq file
             # therefore we can not just always start trimming paired-end even though
             # the samples are paired-end (ish)
-            regex = "[0,1],\d*,\d*:[0,1],\d*,\d*:[0,1],\d*,\d*"
-            assert sampledict[sample]["layout"] == "PAIRED"
-            assert bool(re.search(regex, config.get("count")))
-            bus = [t.split(',') for t in re.findall(regex, config.get("count"))[0].split(":")]   
-            read_id = int(bus[2][0])
+            read_id = get_bustools_rid(config.get("count"))
             if read_id == 0:
                 return expand([f"{{qc_dir}}/fastqc/{sample}_R1_fastqc.zip",
                                f"{{qc_dir}}/fastqc/{sample}_R1_trimmed_fastqc.zip",
@@ -663,12 +659,8 @@ def get_trimming_qc(sample):
                                **config)
 
     elif config["trimmer"] == "fastp":
-        if get_workflow() == "scrna_seq":
-            regex = "[0,1],\d*,\d*:[0,1],\d*,\d*:[0,1],\d*,\d*"
-            assert sampledict[sample]["layout"] == "PAIRED"
-            assert bool(re.search(regex, config.get("count")))
-            bus = [t.split(',') for t in re.findall(regex, config.get("count"))[0].split(":")]   
-            read_id = int(bus[2][0])
+        if get_workflow() == "scrna_seq": 
+            read_id = get_bustools_rid(config.get("count"))
             if read_id == 0:
                 return expand(f"{{qc_dir}}/trimming/{sample}_R1.fastp.json", **config)
             elif read_id == 1:

--- a/seq2science/rules/qc.smk
+++ b/seq2science/rules/qc.smk
@@ -643,7 +643,6 @@ def get_trimming_qc(sample):
                             f"{{qc_dir}}/fastqc/{sample}_R2_trimmed_fastqc.zip",
                             f"{{qc_dir}}/trimming/{sample}_R2.{{fqsuffix}}.gz_trimming_report.txt"],
                             **config)
-
             else:
                 raise NotImplementedError
         else:

--- a/seq2science/rules/quantification.smk
+++ b/seq2science/rules/quantification.smk
@@ -1,3 +1,5 @@
+from seq2science.util import get_bustools_rid
+
 if config["quantifier"] == "salmon":
 
     rule get_transcripts:
@@ -166,11 +168,8 @@ elif config["quantifier"] == "kallistobus":
     def get_kallistobus_reads(wildcards):
         reads = []
         sample = wildcards.sample
-        regex = "[0,1],\d*,\d*:[0,1],\d*,\d*:[0,1],\d*,\d*"
         assert sampledict[sample]["layout"] == "PAIRED"
-        assert bool(re.search(regex, config.get("count")))
-        bus = [t.split(',') for t in re.findall(regex, config.get("count"))[0].split(":")]   
-        read_id = int(bus[2][0])
+        read_id = get_bustools_rid(config.get("count"))
         #Determine mate for trimming
         if read_id == 0:
             reads += expand(f"{{trimmed_dir}}/{sample}_R1_trimmed.{{fqsuffix}}.gz", **config)

--- a/seq2science/rules/quantification.smk
+++ b/seq2science/rules/quantification.smk
@@ -169,13 +169,13 @@ elif config["quantifier"] == "kallistobus":
         regex = "[0,1],\d*,\d*:[0,1],\d*,\d*:[0,1],\d*,\d*"
         assert sampledict[sample]["layout"] == "PAIRED"
         assert bool(re.search(regex, config.get("count")))
-        triplet = [t.split(',') for t in re.findall(regex, config.get("count"))[0].split(":")]   
-        mate_id = int(triplet[2][0])
+        bus = [t.split(',') for t in re.findall(regex, config.get("count"))[0].split(":")]   
+        read_id = int(bus[2][0])
         #Determine mate for trimming
-        if mate_id == 0:
+        if read_id == 0:
             reads += expand("{fastq_dir}/{{sample}}_R2.{fqsuffix}.gz", **config)
             reads += expand(f"{{trimmed_dir}}/{sample}_R1_trimmed.{{fqsuffix}}.gz", **config)
-        elif mate_id == 1:
+        elif read_id == 1:
             reads += expand("{fastq_dir}/{{sample}}_R1.{fqsuffix}.gz", **config)
             reads += expand(f"{{trimmed_dir}}/{sample}_R2_trimmed.{{fqsuffix}}.gz", **config)
         else:    

--- a/seq2science/rules/quantification.smk
+++ b/seq2science/rules/quantification.smk
@@ -166,7 +166,7 @@ elif config["quantifier"] == "kallistobus":
     def get_kallistobus_reads(wildcards):
         reads = []
         sample = wildcards.sample
-        regex = "[0-2],\d*,\d*:[0-2],\d*,\d*:[0-2],\d*,\d*"
+        regex = "[0,1],\d*,\d*:[0,1],\d*,\d*:[0,1],\d*,\d*"
         assert sampledict[sample]["layout"] == "PAIRED"
         assert bool(re.search(regex, config.get("count")))
         triplet = [t.split(',') for t in re.findall(regex, config.get("count"))[0].split(":")]   
@@ -178,10 +178,6 @@ elif config["quantifier"] == "kallistobus":
         elif mate_id == 1:
             reads += expand("{fastq_dir}/{{sample}}_R1.{fqsuffix}.gz", **config)
             reads += expand(f"{{trimmed_dir}}/{sample}_R2_trimmed.{{fqsuffix}}.gz", **config)
-        elif mate_id == 2:
-            reads += expand("{fastq_dir}/{{sample}}_R1.{fqsuffix}.gz", **config)
-            reads += expand("{fastq_dir}/{{sample}}_R2.{fqsuffix}.gz", **config)
-            reads += expand(f"{{trimmed_dir}}/{sample}_R3_trimmed.{{fqsuffix}}.gz", **config)
         else:    
             raise NotImplementedError
 

--- a/seq2science/rules/quantification.smk
+++ b/seq2science/rules/quantification.smk
@@ -166,8 +166,15 @@ elif config["quantifier"] == "kallistobus":
     def get_kallistobus_reads(wildcards):
         reads = []
         sample = wildcards.sample
-        if config.get("protocol") == "celseq":
-            assert sampledict[sample]["layout"] == "PAIRED"
+        assert sampledict[sample]["layout"] == "PAIRED"
+        assert bool(re.search(regex, config.get("count")))
+        triplet = [t.split(',') for t in re.findall(regex, config.get("count"))[0].split(":")]   
+        mate_id = int(triplet[2][0])
+        #Determine mate for trimming
+        if mate_id == 0:
+            reads += expand("{fastq_dir}/{{sample}}_R2.{fqsuffix}.gz", **config)
+            reads += expand(f"{{trimmed_dir}}/{sample}_R1_trimmed.{{fqsuffix}}.gz", **config)
+        elif mate_id == 1:
             reads += expand("{fastq_dir}/{{sample}}_R1.{fqsuffix}.gz", **config)
             reads += expand(f"{{trimmed_dir}}/{sample}_R2_trimmed.{{fqsuffix}}.gz", **config)
         else:

--- a/seq2science/rules/quantification.smk
+++ b/seq2science/rules/quantification.smk
@@ -166,6 +166,7 @@ elif config["quantifier"] == "kallistobus":
     def get_kallistobus_reads(wildcards):
         reads = []
         sample = wildcards.sample
+        regex = "[0-2],\d*,\d*:[0-2],\d*,\d*:[0-2],\d*,\d*"
         assert sampledict[sample]["layout"] == "PAIRED"
         assert bool(re.search(regex, config.get("count")))
         triplet = [t.split(',') for t in re.findall(regex, config.get("count"))[0].split(":")]   
@@ -177,7 +178,11 @@ elif config["quantifier"] == "kallistobus":
         elif mate_id == 1:
             reads += expand("{fastq_dir}/{{sample}}_R1.{fqsuffix}.gz", **config)
             reads += expand(f"{{trimmed_dir}}/{sample}_R2_trimmed.{{fqsuffix}}.gz", **config)
-        else:
+        elif mate_id == 2:
+            reads += expand("{fastq_dir}/{{sample}}_R1.{fqsuffix}.gz", **config)
+            reads += expand("{fastq_dir}/{{sample}}_R2.{fqsuffix}.gz", **config)
+            reads += expand(f"{{trimmed_dir}}/{sample}_R3_trimmed.{{fqsuffix}}.gz", **config)
+        else:    
             raise NotImplementedError
 
         return reads

--- a/seq2science/rules/quantification.smk
+++ b/seq2science/rules/quantification.smk
@@ -173,8 +173,8 @@ elif config["quantifier"] == "kallistobus":
         read_id = int(bus[2][0])
         #Determine mate for trimming
         if read_id == 0:
-            reads += expand("{fastq_dir}/{{sample}}_R2.{fqsuffix}.gz", **config)
             reads += expand(f"{{trimmed_dir}}/{sample}_R1_trimmed.{{fqsuffix}}.gz", **config)
+            reads += expand("{fastq_dir}/{{sample}}_R2.{fqsuffix}.gz", **config)
         elif read_id == 1:
             reads += expand("{fastq_dir}/{{sample}}_R1.{fqsuffix}.gz", **config)
             reads += expand(f"{{trimmed_dir}}/{sample}_R2_trimmed.{{fqsuffix}}.gz", **config)

--- a/seq2science/rules/trimming.smk
+++ b/seq2science/rules/trimming.smk
@@ -90,7 +90,16 @@ elif config["trimmer"] == "fastp":
     if get_workflow() == "scrna_seq":
         all_single_samples = [sample for sample in all_samples if sampledict[sample]["layout"] == "SINGLE"]
         assert len(all_single_samples) == 0
-        all_single_samples = [sample + f"_{config['fqext2']}" for sample in all_samples if sampledict[sample]["layout"] == "PAIRED"]
+        #Check kallisto bustools read id
+        regex = "[0,1],\d*,\d*:[0,1],\d*,\d*:[0,1],\d*,\d*"
+        assert sampledict[sample]["layout"] == "PAIRED"
+        assert bool(re.search(regex, config.get("count")))
+        bus = [t.split(',') for t in re.findall(regex, config.get("count"))[0].split(":")]   
+        read_id = int(bus[2][0])
+        if read_id == 0:
+            all_single_samples = [sample + f"_{config['fqext1']}" for sample in all_samples if sampledict[sample]["layout"] == "PAIRED"]
+        elif read_id == 1:
+            all_single_samples = [sample + f"_{config['fqext2']}" for sample in all_samples if sampledict[sample]["layout"] == "PAIRED"]
         all_paired_samples = []
     else:
         all_single_samples = [sample for sample in all_samples if sampledict[sample]["layout"] == "SINGLE"]

--- a/seq2science/rules/trimming.smk
+++ b/seq2science/rules/trimming.smk
@@ -1,3 +1,5 @@
+from seq2science.util import get_bustools_rid
+
 if config["trimmer"] == "trimgalore":
     if "scrna_seq" == get_workflow():
         ruleorder: trimgalore_SE > trimgalore_PE
@@ -86,20 +88,18 @@ elif config["trimmer"] == "fastp":
     else:
         ruleorder: fastp_PE > fastp_SE
 
-
     if get_workflow() == "scrna_seq":
         all_single_samples = [sample for sample in all_samples if sampledict[sample]["layout"] == "SINGLE"]
         assert len(all_single_samples) == 0
         #Check kallisto bustools read id
-        regex = "[0,1],\d*,\d*:[0,1],\d*,\d*:[0,1],\d*,\d*"
-        assert sampledict[sample]["layout"] == "PAIRED"
-        assert bool(re.search(regex, config.get("count")))
-        bus = [t.split(',') for t in re.findall(regex, config.get("count"))[0].split(":")]   
-        read_id = int(bus[2][0])
+        read_id = get_bustools_rid(config.get("count"))
         if read_id == 0:
             all_single_samples = [sample + f"_{config['fqext1']}" for sample in all_samples if sampledict[sample]["layout"] == "PAIRED"]
         elif read_id == 1:
             all_single_samples = [sample + f"_{config['fqext2']}" for sample in all_samples if sampledict[sample]["layout"] == "PAIRED"]
+        else:
+            raise NotImplementedError
+
         all_paired_samples = []
     else:
         all_single_samples = [sample for sample in all_samples if sampledict[sample]["layout"] == "SINGLE"]

--- a/seq2science/schemas/config/scrna.schema.yaml
+++ b/seq2science/schemas/config/scrna.schema.yaml
@@ -23,6 +23,4 @@ properties:
   barcodefile:
     type: string
 
-  protocol:
-    type: string
-    enum: [celseq]
+  

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pysradb
 from snakemake.io import expand
 from snakemake.exceptions import TerminatedException
-
+import re
 
 def _sample_to_idxs(df: pd.DataFrame, sample: str) -> List[int]:
     """
@@ -223,3 +223,10 @@ def url_is_alive(url):
         except:
             continue
     return False
+
+def get_bustools_rid(params):
+    regex = "[0,1],\d*,\d*:[0,1],\d*,\d*:[0,1],\d*,\d*"
+    assert bool(re.search(regex, params)),"Incorrect bc:umi:read format (See https://pachterlab.github.io/kallisto/manual)"
+    bus = re.findall(regex, params)[0].split(":")
+    read_id = bus[2].split(",")
+    return int(read_id[0])

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -245,4 +245,4 @@ def get_bustools_rid(params):
         read_id = kb_tech_dict[tech.lower()]
     else:
         raise Exception("Not a valid scrna-seq platform. Please check -x parameter")
-    return read_id∏
+    return read_id

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -1,6 +1,7 @@
 """
 Utility functions for seq2science
 """
+import re
 import os
 import sys
 from typing import List
@@ -11,7 +12,7 @@ import pandas as pd
 import pysradb
 from snakemake.io import expand
 from snakemake.exceptions import TerminatedException
-import re
+
 
 def _sample_to_idxs(df: pd.DataFrame, sample: str) -> List[int]:
     """

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -224,9 +224,25 @@ def url_is_alive(url):
             continue
     return False
 
+#def get_bustools_rid(params):
+#    regex = "[0,1],\d*,\d*:[0,1],\d*,\d*:[0,1],\d*,\d*"
+#    assert bool(re.search(regex, params)),"Incorrect bc:umi:read format (See https://pachterlab.github.io/kallisto/manual)"
+#    bus = re.findall(regex, params)[0].split(":")
+#    read_id = bus[2].split(",")
+#    return int(read_id[0])
+
 def get_bustools_rid(params):
-    regex = "[0,1],\d*,\d*:[0,1],\d*,\d*:[0,1],\d*,\d*"
-    assert bool(re.search(regex, params)),"Incorrect bc:umi:read format (See https://pachterlab.github.io/kallisto/manual)"
-    bus = re.findall(regex, params)[0].split(":")
-    read_id = bus[2].split(",")
-    return int(read_id[0])
+    kb_tech_dict = { '10xv2': 1,'10xv3': 1,'celseq': 1,'celseq2': 1,'dropseq': 1,'scrubseq': 1 }
+    #Check for occurence of short-hand tech
+    bus_regex = "[0-1],\d*,\d*:[0-1],\d*,\d*:[0-1],\d*,\d*"
+    bus_regex_short = "\\b(?i)(10XV2|10XV3|CELSEQ|CELSEQ2|DROPSEQ|SCRUBSEQ)\\b"
+    read_id = None
+    if re.search(bus_regex, params) != None:
+        bus = re.findall(bus_regex, params)[0]
+        read_id = int(bus.split(":")[2].split(",")[0])
+    elif re.search(bus_regex_short, params) != None:
+        tech = re.findall(bus_regex_short, params)[0]
+        read_id = kb_tech_dict[tech.lower()]
+    else:
+        raise Exception("Not a valid scrna-seq platform. Please check -x parameter")
+    return read_id∏

--- a/seq2science/workflows/scrna_seq/config.yaml
+++ b/seq2science/workflows/scrna_seq/config.yaml
@@ -5,7 +5,8 @@ samples: samples.tsv
 result_dir: ./results  # where to store results
 genome_dir: ./genomes  # where to look for or download the genomes
 # fastq_dir: (default is inside result_dir) # where to look for fastqs
-
+bigwig_dir: ./bigwig
+deeptools_flags: ""
 
 # contact info for multiqc report and trackhub
 email: yourmail@here.com

--- a/seq2science/workflows/scrna_seq/config.yaml
+++ b/seq2science/workflows/scrna_seq/config.yaml
@@ -14,12 +14,11 @@ email: yourmail@here.com
 technical_replicates: merge
 
 # scRNA options
+# the umi/bc/read order is automatically infered from the -x parameter (https://pachterlab.github.io/kallisto/manual).
+# seq2science does currently not support scrna-seq platforms that generate more than two fastq files, such as 10xv1.
 quantifier:
   kallistobus:
     ref: '--lamanno'
     count: '-x 0,8,16:0,0,8:1,0,0 --verbose --lamanno'
 
-# currently only supported protocol is celseq, please make issue on github
-# if you want another supported: https://github.com/vanheeringen-lab/seq2science
-protocol: celseq
 barcodefile: "barcodes.txt"

--- a/seq2science/workflows/scrna_seq/config.yaml
+++ b/seq2science/workflows/scrna_seq/config.yaml
@@ -15,11 +15,10 @@ email: yourmail@here.com
 technical_replicates: merge
 
 # scRNA options
-# the umi/bc/read order is automatically infered from the -x parameter (https://pachterlab.github.io/kallisto/manual).
 # seq2science does currently not support scrna-seq platforms that generate more than two fastq files, such as 10xv1.
 quantifier:
   kallistobus:
     ref: '--lamanno'
     count: '-x 0,8,16:0,0,8:1,0,0 --verbose --lamanno'
-
+    #count: '-x 10XV2 --verbose --lamanno'
 barcodefile: "barcodes.txt"


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
- Kallistobus scrna-platform is automatically infered from busformat parameter `-x bc:umi:reads`
- Support for Kallistobus short-hand syntax (10xV2, Celseq etc.) as alternative to busformat 
- Set R1/R2 read for trimming (fastp) based on Kallistobus `-x` parameter. Reads can be contained in either R1 or R2 fastq
 

**What did change**
Explain clearly and concisely what you changed. Why did you take certain design decisions?

**Checklist**
- [x] I made a PR to scRNA_kb (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [ ] These changes are covered by the tests
