### PR TITLE
public scATAC edge-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ### Changed
 
+- sample layout lookup is split up in 100's, to avoid a jsondecodeerror which results from very long lists of samples
 - the multiqc samples & config tables are generated in a script with its own environment to make base env smaller
 - keep_mates for macs2 turned into a script with ts own environment ot make the base env smaller
 - seq2science cache now respects the xdg cache

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -161,7 +161,15 @@ def samples2metadata(samples: List[str], config: dict, logger) -> dict:
     if len(public_samples) == 0:
         return local_samples
 
-    sra_samples = samples2metadata_sra(public_samples, logger)
+    # chop public samples into smaller chunks, doing large queries results into
+    # pysradb decode errors..
+    chunksize = 100
+    chunked_public = [public_samples[i:i+chunksize] for i in range(0, len(public_samples), chunksize)]
+    sra_samples = dict()
+    for chunk in chunked_public:
+        sra_samples.update(samples2metadata_sra(chunk, logger))
+        # just to be sure sleep in between to not go over our API limit
+        time.sleep(1)
 
     return {**local_samples, **sra_samples}
 


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
When using a large amount of public data, e.g. scATAC, somehow pysradb gives a decodeerror. By splitting up the lookup in chunks we should avoid it.

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
