### PR TITLE
fix trackhub naming bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ## [Unreleased]
 
+### Fixed
+
+- bug in chip/atac trackhub generation where peaks and bigwigs used the same name, resulting in collisions and a trackhub that does not want to load 
+
 ## [0.3.2] - 2020-11-26
 
 ### Added

--- a/seq2science/rules/merge_replicates.smk
+++ b/seq2science/rules/merge_replicates.smk
@@ -56,12 +56,13 @@ def rep_to_descriptive(rep, brep=False):
     """
     if "descriptive_name" in samples:
         if brep and "condition" in samples:
-            col = samples.condition
-        elif "replicate" in samples:
-            col = samples.replicate
+            rep = samples[samples.condition == rep].condition[0]
         else:
-            col = samples.index
-        rep = samples[col == rep].descriptive_name[0]
+            if "replicate" in samples:
+                col = samples.replicate
+            else:
+                col = samples.index
+            rep = samples[col == rep].descriptive_name[0]
     return rep
 
 

--- a/seq2science/rules/trackhub.smk
+++ b/seq2science/rules/trackhub.smk
@@ -540,7 +540,7 @@ def create_trackhub():
                         file = f"{config['result_dir']}/{peak_caller}/{assembly}-{trep}.bw"
                         priority += 1.0
                         track = trackhub.Track(
-                            name            = trackhub.helpers.sanitize(f"{descriptive}{peak_caller_suffix} bw"),
+                            name            = trackhub.helpers.sanitize(f"{rep_to_descriptive(trep)}{peak_caller_suffix} bw"),
                             tracktype       = "bigWig",
                             short_label     = f"{shorten(rep_to_descriptive(trep), 14-len(pcs), ['signs', 'vowels', 'center'])}{pcs} bw",  # <= 17 characters suggested
                             long_label      = f"{rep_to_descriptive(trep)}{peak_caller_suffix} bigWig",


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
Small bug in trackhub names for atac and chip. This caused collisions and the whole trackhub did not load

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
