### PR TITLE
Idr fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 - bug in chip/atac trackhub generation where peaks and bigwigs used the same name, resulting in collisions and a trackhub that does not want to load 
 - (literal) genome edge-case where taking the slop of peaks results in identical peaks. One of the duplicates is removed.
+- IDR should work again
 
 ## [0.3.2] - 2020-11-26
 

--- a/seq2science/envs/macs2.yaml
+++ b/seq2science/envs/macs2.yaml
@@ -7,3 +7,4 @@ dependencies:
   - bioconda::macs2=2.2.7
   - bioconda::khmer=2.0
   - conda-forge::jq=1.6
+  - anaconda::setuptools=v50.3.1

--- a/seq2science/rules/peak_calling.smk
+++ b/seq2science/rules/peak_calling.smk
@@ -283,6 +283,9 @@ if "condition" in samples:
             """
             Combine replicates based on the irreproducible discovery rate (IDR). Can only handle two replicates.
             For more than two replicates use fisher's method.
+
+            When combining narrowpeak files we make the q-score zero, and the peak summit in the middle. This is
+            necessary for later downstream processing, but are not the "true" values.
             """
             input:
                 get_idr_replicates,
@@ -307,7 +310,7 @@ if "condition" in samples:
                 else
                     idr --samples {input} {params.rank} --output-file {output.temp} > {log} 2>&1
                     if [ "{wildcards.ftype}" == "narrowPeak" ]; then
-                        awk 'IFS="\t",OFS="\t" {{$10=int(($2 + $3) / 2)}}' {output.temp} > {output.true} 2>> {log}
+                        awk 'IFS="\t",OFS="\t" {{$9=0; $10=int(($3 - $2) / 2); print}}' {output.temp} > {output.true} 2>> {log}
                     else
                         cp {output.temp} {output.true}
                     fi

--- a/seq2science/rules/peak_calling.smk
+++ b/seq2science/rules/peak_calling.smk
@@ -284,8 +284,9 @@ if "condition" in samples:
             Combine replicates based on the irreproducible discovery rate (IDR). Can only handle two replicates.
             For more than two replicates use fisher's method.
 
-            When combining narrowpeak files we make the q-score zero, and the peak summit in the middle. This is
-            necessary for later downstream processing, but are not the "true" values.
+            When combining narrowpeak files with IDR, the q-score and summit are set to -1 (means not set). However some
+            downstream tools require these to be set. So we set the q-score to zero, and place the summit of the peak in
+            the middle of the peak.
             """
             input:
                 get_idr_replicates,

--- a/seq2science/rules/peak_calling.smk
+++ b/seq2science/rules/peak_calling.smk
@@ -306,7 +306,11 @@ if "condition" in samples:
                     touch {output.temp}
                 else
                     idr --samples {input} {params.rank} --output-file {output.temp} > {log} 2>&1
-                    awk 'IFS="\t",OFS="\t" {{print $1, $2, $3, $4, 0}}' {output.temp} > {output.true} 2>> {log}
+                    if [ "{wildcards.ftype}" == "narrowPeak" ]; then
+                        awk 'IFS="\t",OFS="\t" {{$10=int(($2 + $3) / 2)}}' {output.temp} > {output.true} 2>> {log}
+                    else
+                        cp {output.temp} {output.true}
+                    fi
                 fi
                 """
 


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
IDR narrowpeaks did not work with combine_peaks. Now does (by hacking the summit in the middle of the peak). I had some issues with the macs2 and khmer, and adding setuptools fixed it. Not sure why or what was happening there..

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [ ] I updated the CHANGELOG
- [ ] These changes are covered by the tests
