### PR TITLE
star_align log

### DIFF
--- a/seq2science/rules/alignment.smk
+++ b/seq2science/rules/alignment.smk
@@ -410,7 +410,7 @@ elif config["aligner"] == "star":
             pipe=pipe(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}.samtools-coordinate.pipe", **config)[0]),
             dir=directory(expand("{result_dir}/{aligner}/{{assembly}}-{{sample}}", **config)),
         log:
-            expand("{log_dir}/{aligner}_align/{{assembly}}-{{sample}}.log", **config),
+            directory(expand("{log_dir}/{aligner}_align/{{assembly}}-{{sample}}", **config)),
         benchmark:
             expand("{benchmark_dir}/{aligner}_align/{{assembly}}-{{sample}}.benchmark.txt", **config)[0]
         message: explain_rule(f"{config['aligner']}_align")


### PR DESCRIPTION
Simple name change as the directory looked like a file.


More cleanup possible: The STAR output directory only contains the SJ.out.tab.

The SJ.out.tab is used in the 2-pass system for _de novo_ alignment, which we don't support, but might be interesting to others.
We could leave it as-is, or lose it, or leave it in the log directory*. With the latter two options we can make the output.dir a temporary directory. What do you think?

*STAR itself considers the file as a Log file
