### PR TITLE
DESeq2.R from CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ### Added
 
+- added CLI functionality to the deseq2.R script (try it with `Rscript /path/to/deseq2.R --help`!)
 - --force flag to seq2science init to automatically overwrite existing samples.tsv and config.yaml
 - local fastqs with Illumina's '_100' are now recognized
 

--- a/docs/content/DESeq2.md
+++ b/docs/content/DESeq2.md
@@ -2,11 +2,12 @@
 Seq2science outputs counts matrices for each assembly in any bulk-sequencing workflow, which can optionally can be used for differential gene/peak analysis with [DESeq2](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-014-0550-8).
 To do so, add one or more contrast design(s) in the `config.yaml` file, with matching identifiers in the `samples.tsv` file.
 
+After completing the workflow, rerunning Seq2science with new contrasts will only perform the new analyses.
+Alternatively, you can call the DESeq2 script from the command line.
+To get started with the command line script, try out `Rscript /path/to/seq2science/scripts/deseq2.R --help`.
+
 This section details how the contrast designs are created.
 Examples are given [below](./DESeq2.html#deseq2-contrast-designs), and each `config.yaml` contains a commented-out example contrast design at the bottom.
-
-Note: (additional) design contrasts can be added at any time.
-After completing the workflow, rerunning Seq2science with new contrasts will only perform the new analyses.
 
 ##### Overview of the DESeq2 method
 DESeq2 automatically performs library bias correction when loading your data, and batch correction is performed if it is included in the contrast design.

--- a/seq2science/rules/deseq2.smk
+++ b/seq2science/rules/deseq2.smk
@@ -71,11 +71,12 @@ rule deseq2:
         samples=os.path.abspath(config["samples"]),
         replicates=True if "technical_replicate" in samples else False,
         salmon=config.get("quantifier","") == "salmon",
+        script_dir=f"{config['rule_dir']}/../scripts"
     resources:
         R_scripts=1, # conda's R can have issues when starting multiple times
         mem_gb=4,
     script:
-        f"{config['rule_dir']}/../scripts/deseq2.R"
+        f"{config['rule_dir']}/../scripts/deseq2_rule.R"
 
 
 rule blind_clustering:

--- a/seq2science/rules/deseq2.smk
+++ b/seq2science/rules/deseq2.smk
@@ -76,7 +76,7 @@ rule deseq2:
         R_scripts=1, # conda's R can have issues when starting multiple times
         mem_gb=4,
     script:
-        f"{config['rule_dir']}/../scripts/deseq2_rule.R"
+        f"{config['rule_dir']}/../scripts/deseq2.R"
 
 
 rule blind_clustering:

--- a/seq2science/rules/deseq2.smk
+++ b/seq2science/rules/deseq2.smk
@@ -71,7 +71,7 @@ rule deseq2:
         samples=os.path.abspath(config["samples"]),
         replicates=True if "technical_replicate" in samples else False,
         salmon=config.get("quantifier","") == "salmon",
-        script_dir=f"{config['rule_dir']}/../scripts"
+        scripts_dir=f"{config['rule_dir']}/../scripts"
     resources:
         R_scripts=1, # conda's R can have issues when starting multiple times
         mem_gb=4,

--- a/seq2science/scripts/deseq2.R
+++ b/seq2science/scripts/deseq2.R
@@ -144,12 +144,15 @@ cat('\n')
 expressed_genes <- as.data.frame(resLFC[order(resLFC$padj),])
 
 missing_genes <- rownames(counts)[!(rownames(counts) %in% rownames(expressed_genes))]
-unexpressed_genes <- as.data.frame(matrix(data = NA, ncol = ncol(expressed_genes), nrow = length(missing_genes)))
-rownames(unexpressed_genes) <- missing_genes
-colnames(unexpressed_genes) <- colnames(expressed_genes)
-unexpressed_genes[,'baseMean'] <- 0
-
-all_genes <- rbind(expressed_genes, unexpressed_genes)
+if (length(missing_genes) > 0){
+    unexpressed_genes <- as.data.frame(matrix(data = NA, ncol = ncol(expressed_genes), nrow = length(missing_genes)))
+    rownames(unexpressed_genes) <- missing_genes
+    colnames(unexpressed_genes) <- colnames(expressed_genes)
+    unexpressed_genes[,'baseMean'] <- 0
+    all_genes <- rbind(expressed_genes, unexpressed_genes)
+} else {
+    all_genes <- expressed_genes
+}
 write.table(all_genes, file=output, quote = F, sep = '\t', col.names=NA)
 cat('DE genes table saved\n\n')
 

--- a/seq2science/scripts/deseq2.R
+++ b/seq2science/scripts/deseq2.R
@@ -1,6 +1,18 @@
 #!/usr/bin/env Rscript
 
-# IMPORTANT: This script should be called from deseq2_standalone.R or deseq2_rule.R
+# input method
+if (exists("snakemake")){
+  # parse seq2science input
+  scripts_dir <- snakemake@params$scripts_dir
+  deseq_wrapper <- file.path(scripts_dir, "deseq2_rule.R")
+} else {
+  # parse command line input
+  cli_args    <- commandArgs(trailingOnly=F)
+  this_script <- sub("--file=", "", cli_args[grep("--file=", cli_args)])
+  scripts_dir <- dirname(this_script)
+  deseq_wrapper <- file.path(scripts_dir, "deseq2_standalone.R")
+}
+source(deseq_wrapper)
 
 ## parse the design contrast
 # a contrast is always in the form 'batch+condition_group1_group2', where batch(+) is optional

--- a/seq2science/scripts/deseq2.R
+++ b/seq2science/scripts/deseq2.R
@@ -1,49 +1,6 @@
-suppressMessages({
-  library(DESeq2)
-  library(BiocParallel)
-  library(IHW)
-  library(ggplot2)
-})
+#!/usr/bin/env Rscript
 
-# snakemake variables
-threads         <- snakemake@threads[[1]]
-log_file        <- snakemake@log[[1]]
-counts_file     <- snakemake@input[[1]]
-samples_file    <- snakemake@params$samples
-replicates      <- snakemake@params$replicates
-contrast        <- snakemake@wildcards$contrast
-mtp             <- snakemake@config$deseq2$multiple_testing_procedure
-fdr             <- snakemake@config$deseq2$alpha_value
-se              <- snakemake@config$deseq2$shrinkage_estimator
-assembly        <- snakemake@wildcards$assembly
-salmon          <- snakemake@params$salmon
-output          <- snakemake@output[[1]]
-
-# log all console output
-log <- file(log_file, open="wt")
-sink(log)
-sink(log, type="message")
-
-# log all variables for debugging purposes
-cat('# variables used for this analysis:\n')
-cat('threads      <-',   threads, '\n')
-cat('log_file     <- "', log_file,     '"\n', sep = "")
-cat('counts_file  <- "', counts_file,  '"\n', sep = "")
-cat('samples_file <- "', samples_file, '"\n', sep = "")
-cat('replicates   <- ',  replicates, '\n')
-cat('contrast     <- "', contrast,     '"\n', sep = "")
-cat('mtp          <- "', mtp,          '"\n', sep = "")
-cat('fdr          <-',   fdr, '\n')
-cat('se           <- "', se,           '"\n', sep = "")
-cat('assembly     <- "', assembly,     '"\n', sep = "")
-cat('salmon       <- ', salmon,       '\n', sep = "")
-cat('output       <- "', output,       '"\n', sep = "")
-cat('\n')
-
-cat('Sessioninfo:\n')
-sessionInfo()
-cat('\n')
-
+# IMPORTANT: This script should be called from deseq2_standalone.R or deseq2_rule.R
 
 ## parse the design contrast
 # a contrast is always in the form 'batch+condition_group1_group2', where batch(+) is optional

--- a/seq2science/scripts/deseq2_rule.R
+++ b/seq2science/scripts/deseq2_rule.R
@@ -1,0 +1,54 @@
+#!/usr/bin/env Rscript
+
+suppressMessages({
+  library(DESeq2)
+  library(BiocParallel)
+  library(IHW)
+  library(ggplot2)
+})
+
+# snakemake variables
+threads         <- snakemake@threads[[1]]
+log_file        <- snakemake@log[[1]]
+counts_file     <- snakemake@input[[1]]
+samples_file    <- snakemake@params$samples
+scripts_dir     <- snakemake@params$scripts_dir
+replicates      <- snakemake@params$replicates
+contrast        <- snakemake@wildcards$contrast
+mtp             <- snakemake@config$deseq2$multiple_testing_procedure
+fdr             <- snakemake@config$deseq2$alpha_value
+se              <- snakemake@config$deseq2$shrinkage_estimator
+assembly        <- snakemake@wildcards$assembly
+salmon          <- snakemake@params$salmon
+output          <- snakemake@output[[1]]
+
+# log all console output
+log <- file(log_file, open="wt")
+sink(log)
+sink(log, type="message")
+
+# log all variables for debugging purposes
+cat('# variables used for this analysis:\n')
+cat('threads      <-',   threads, '\n')
+cat('log_file     <- "', log_file,     '"\n', sep = "")
+cat('counts_file  <- "', counts_file,  '"\n', sep = "")
+cat('samples_file <- "', samples_file, '"\n', sep = "")
+cat('scripts_dir  <- "', scripts_dir,  '"\n', sep = "")
+cat('replicates   <- ',  replicates, '\n')
+cat('contrast     <- "', contrast,     '"\n', sep = "")
+cat('mtp          <- "', mtp,          '"\n', sep = "")
+cat('fdr          <-',   fdr, '\n')
+cat('se           <- "', se,           '"\n', sep = "")
+cat('assembly     <- "', assembly,     '"\n', sep = "")
+cat('salmon       <- ', salmon,       '\n', sep = "")
+cat('output       <- "', output,       '"\n', sep = "")
+cat('\n')
+
+cat('Sessioninfo:\n')
+sessionInfo()
+cat('\n')
+
+
+# run the core script
+deseq_script <- file.path(scripts_dir, "deseq2.R")
+source(deseq_script)

--- a/seq2science/scripts/deseq2_rule.R
+++ b/seq2science/scripts/deseq2_rule.R
@@ -12,7 +12,6 @@ threads         <- snakemake@threads[[1]]
 log_file        <- snakemake@log[[1]]
 counts_file     <- snakemake@input[[1]]
 samples_file    <- snakemake@params$samples
-scripts_dir     <- snakemake@params$scripts_dir
 replicates      <- snakemake@params$replicates
 contrast        <- snakemake@wildcards$contrast
 mtp             <- snakemake@config$deseq2$multiple_testing_procedure
@@ -29,26 +28,20 @@ sink(log, type="message")
 
 # log all variables for debugging purposes
 cat('# variables used for this analysis:\n')
-cat('threads      <-',   threads, '\n')
+cat('threads      <- ',  threads,      '\n',  sep = "")
 cat('log_file     <- "', log_file,     '"\n', sep = "")
 cat('counts_file  <- "', counts_file,  '"\n', sep = "")
 cat('samples_file <- "', samples_file, '"\n', sep = "")
-cat('scripts_dir  <- "', scripts_dir,  '"\n', sep = "")
-cat('replicates   <- ',  replicates, '\n')
+cat('replicates   <- ',  replicates,   '\n',  sep = "")
 cat('contrast     <- "', contrast,     '"\n', sep = "")
 cat('mtp          <- "', mtp,          '"\n', sep = "")
-cat('fdr          <-',   fdr, '\n')
+cat('fdr          <- ',  fdr,          '\n',  sep = "")
 cat('se           <- "', se,           '"\n', sep = "")
 cat('assembly     <- "', assembly,     '"\n', sep = "")
-cat('salmon       <- ', salmon,       '\n', sep = "")
+cat('salmon       <- ',  salmon,       '\n',  sep = "")
 cat('output       <- "', output,       '"\n', sep = "")
 cat('\n')
 
 cat('Sessioninfo:\n')
 sessionInfo()
 cat('\n')
-
-
-# run the core script
-deseq_script <- file.path(scripts_dir, "deseq2.R")
-source(deseq_script)

--- a/seq2science/scripts/deseq2_standalone.R
+++ b/seq2science/scripts/deseq2_standalone.R
@@ -48,10 +48,6 @@ if (!dir.exists(out_dir)){
 }
 
 # variables required in the core script
-all_args    <- commandArgs(trailingOnly=F)
-this_script <- sub("--file=", "", all_args[grep("--file=", all_args)])
-scripts_dir <- dirname(this_script)
-
 samples     <- read.delim(samples_file, sep = "\t", na.strings = "", comment.char = "#", stringsAsFactors = F, row.names = "sample")
 replicates  <- "technical_replicate" %in% colnames(samples)  # always merge replicates if "technical_replicate" exists
 assembly    <- samples$assembly[1]                           # always use the first assembly
@@ -69,8 +65,3 @@ suppressMessages({
   library(IHW)
   library(ggplot2)
 })
-
-
-# run the core script
-deseq_script <- file.path(scripts_dir, "deseq2.R")
-source(deseq_script)

--- a/seq2science/scripts/deseq2_standalone.R
+++ b/seq2science/scripts/deseq2_standalone.R
@@ -1,0 +1,76 @@
+#!/usr/bin/env Rscript
+
+args = commandArgs(trailingOnly=TRUE)
+
+# help message
+if ("--help" %in% args || "-h" %in% args) {
+  cat('\nUSAGE:\n  ./deseq2.R [1]contrast [2]/path/to/samples_file [3]/path/to/counts_file [4]/path/to/out_dir  \n\n')
+  quit(save = "no" , status = 0)
+}
+
+# conda environment
+required_packages <- c("DESeq2", "BiocParallel", "IHW", "ggplot2")
+installed_packages <- installed.packages()[,"Package"]
+for (pkg in required_packages){
+  if ( !(pkg %in% installed_packages) ){
+    cat('Please activate a conda environment with DESeq2, BiocParallel, IHW and ggplot2.  \n\n')
+    quit(save = "no" , status = 0)
+  }
+}
+
+# parse arguments
+if (!length(args)==4) {
+  cat("4 arguments expected: contrast, samples_file, counts_file and outdir.")
+  quit(save = "no" , status = 0)
+}
+contrast     <- args[1]
+samples_file <- args[2]
+counts_file  <- args[3]
+out_dir      <- args[4]
+
+if (!length(strsplit(contrast, '_')[[1]]) >= 3){
+  cat("Contrast must contain a column name and two fields separated with an underscore (_).  \n\n")
+  quit(save = "no" , status = 0)
+}
+
+if (!file.exists(samples_file)){
+  cat("Cannot find the samples_file.  \n\n")
+  quit(save = "no" , status = 0)
+}
+
+if (!file.exists(counts_file)){
+  cat("Cannot find the counts_file.  \n\n")
+  quit(save = "no" , status = 0)
+}
+
+if (!dir.exists(out_dir)){
+  dir.create(out_dir, showWarnings = F, recursive = T)
+}
+
+# variables required in the core script
+all_args    <- commandArgs(trailingOnly=F)
+this_script <- sub("--file=", "", all_args[grep("--file=", all_args)])
+scripts_dir <- dirname(this_script)
+
+samples     <- read.delim(samples_file, sep = "\t", na.strings = "", comment.char = "#", stringsAsFactors = F, row.names = "sample")
+replicates  <- "technical_replicate" %in% colnames(samples)  # always merge replicates if "technical_replicate" exists
+assembly    <- samples$assembly[1]                           # always use the first assembly
+mtp         <- "BH"                                          # \
+fdr         <- 0.1                                           #  |-default options only
+se          <- "apeglm"                                      # /
+salmon      <- FALSE                                         # only work with counts data
+threads     <- 1
+output      <- file.path(out_dir, paste0(assembly, "-", contrast, ".diffexp.tsv"))
+
+# load libraries
+suppressMessages({
+  library(DESeq2)
+  library(BiocParallel)
+  library(IHW)
+  library(ggplot2)
+})
+
+
+# run the core script
+deseq_script <- file.path(scripts_dir, "deseq2.R")
+source(deseq_script)


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
So you wanna perform DESeq2, but you dont want to run seq2science again? OK, now you can with 
```
Rscript /path/to/s2s/seq2science/scripts/deseq2.R --help
```

**What did change**
The DESeq2 script is now split into the core script and two wrappers: one for the rule, one for the user. 
The standalone script is a bit more limited: only 1 assembly, the "technical_replicates" column is always merged, and only default config options available...

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
