### PR TITLE
doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - scRNA can use fqexts other than R1/R2
 - fastq renaming works again
 - added missing schemas to extended docs
-
-### Fixed
-
 - Bug with edgeR.upperquartile normalization. Now makes everything NaN, so pipeline finishes succesfully.
 
 ## [0.5.0] - 2021-03-03

--- a/seq2science/rules/alignment.smk
+++ b/seq2science/rules/alignment.smk
@@ -346,15 +346,15 @@ elif config["aligner"] == "star":
         Make a genome index for STAR.
 
         Troubleshooting:
-        1) sufficient RAM & disk space?
-        2) increase the RAM available (--limitGenomeGenerateRAM)
-        3) reduce the number of threads (seq2science -j 5)
-        4) reduce accuracy (--genomeSAsparseD 2)
+        1. sufficient RAM & disk space?
+        2. increase the RAM available (--limitGenomeGenerateRAM)
+        3. reduce the number of threads (seq2science -j 5)
+        4. reduce accuracy (--genomeSAsparseD 2)
 
-        In your config.yaml:
-        aligner:
-            star:
-                index: --limitGenomeGenerateRAM 60000000000 --genomeSAsparseD 1
+        In your config.yaml, add:
+         aligner:
+          star:
+           index: --limitGenomeGenerateRAM 60000000000 --genomeSAsparseD 1
         """
         input:
             genome=expand("{genome_dir}/{{assembly}}/{{assembly}}.fa", **config),

--- a/seq2science/rules/bam_cleaning.smk
+++ b/seq2science/rules/bam_cleaning.smk
@@ -92,6 +92,7 @@ rule sieve_bam:
         * remove multimappers
         * remove reads inside the blacklist
         * filter paired-end reads on transcript length
+     
     """
     input:
         bam=rules.samtools_presort.output,

--- a/seq2science/rules/trackhub.smk
+++ b/seq2science/rules/trackhub.smk
@@ -175,8 +175,8 @@ rule trackhub_index:
     """
     Generate a searchable annotation & index for each assembly
 
-    sources: https://genome.ucsc.edu/goldenPath/help/hubQuickStartSearch.html
-             https://www.biostars.org/p/272649/
+    sources: https://genome.ucsc.edu/goldenPath/help/hubQuickStartSearch.html, 
+    https://www.biostars.org/p/272649/
     """
     input:
         sizes=expand("{genome_dir}/{{assembly}}/{{assembly}}.fa.sizes", **config),


### PR DESCRIPTION
Sneaky push to master to fix the docs only.

The missing _whiteline with an extra space_ in `bam_cleaning.smk` was breaking the chapter "per rule explanation"...
The rest just looks a little better.