### PR TITLE
no output.allsizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ## [Unreleased]
 
+### Changed
+
+- fixed bug with seq2science making a {output.allsizes} file
+
 ## [0.5.2] - 2021-05-10
 
 ### Added

--- a/seq2science/rules/bam_cleaning.smk
+++ b/seq2science/rules/bam_cleaning.smk
@@ -111,7 +111,8 @@ rule sieve_bam:
     params:
         minqual=f"-q {config['min_mapping_quality']}",
         atacshift=(
-            lambda wildcards, input: f" {config['rule_dir']}/../scripts/atacshift.pl /dev/stdin {input.sizes} | "
+            lambda wildcards, input:
+            f" {config['rule_dir']}/../scripts/atacshift.pl /dev/stdin {input.sizes} | "
             if config["tn5_shift"]
             else ""
         ),
@@ -123,7 +124,12 @@ rule sieve_bam:
             if sampledict[wildcards.sample]["layout"] == "PAIRED" and config["filter_on_size"]
             else ""
         ),
-        sizesieve_touch="touch {output.allsizes}" if config["filter_on_size"] else ""
+        sizesieve_touch=(
+            lambda wildcards, input, output:
+            f"touch {output.allsizes}"
+            if sampledict[wildcards.sample]["layout"] == "SINGLE" and config["filter_on_size"]
+            else ""
+        ),
     shell:
         """
         samtools view -h {params.prim_align} {params.minqual} {params.blacklist} \


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
I happen to get a {output.allsizes} file. This should fix that. Not sure why this did not cause errors..? Never single-end atac?

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
