### PR TITLE
Optional barcode whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ## [Unreleased]
 
+## Changed
+
+- optional barcodefile argument for scRNA-seq workflow 
+
 ### Added
 
 - added support for kb-python kite workflow

--- a/seq2science/rules/quantification.smk
+++ b/seq2science/rules/quantification.smk
@@ -280,9 +280,9 @@ elif config["quantifier"] == "kallistobus":
             Align reads against a transcriptome (index) with kallistobus and output a quantification file per sample.
             """
             input:
-                barcodefile=config["barcodefile"],
                 basedir=get_kb_dir,
-                reads=rules.fastq_pair.output.reads
+                reads=rules.fastq_pair.output.reads,
+                barcodefile=expand(["{barcodefile}"] if 'barcodefile' in config else [],**config),
             output:
                 dir=directory(expand("{result_dir}/{quantifier}/{{assembly}}-{{sample}}",**config))
             log:
@@ -298,14 +298,15 @@ elif config["quantifier"] == "kallistobus":
                 mem_gb=66,
             params:
                 basename=lambda wildcards, input: f"{input.basedir[0]}/{wildcards.assembly}",
+                barcode_arg=lambda wildcards, input: "-w " + input.barcodefile[0] if input.barcodefile else "", 
                 options=config.get("count")
             shell:
                 """
                 kb count \
-                -i {params.basename}.idx -w {input.barcodefile} \
+                -i {params.basename}.idx \
                 -t {threads} -g {params.basename}_t2g.txt \
                 -o {output} -c1 {params.basename}_cdna_t2c.txt -c2 {params.basename}_intron_t2c.txt \
-                {params.options} {input.reads} > {log} 2>&1
+                {params.barcode_arg} {params.options} {input.reads} > {log} 2>&1
                 """                
                  
                  

--- a/seq2science/rules/quantification.smk
+++ b/seq2science/rules/quantification.smk
@@ -282,7 +282,7 @@ elif config["quantifier"] == "kallistobus":
             input:
                 basedir=get_kb_dir,
                 reads=rules.fastq_pair.output.reads,
-                barcodefile=expand(["{barcodefile}"] if 'barcodefile' in config else [],**config),
+                barcodefile=config.get("barcodefile",[]),
             output:
                 dir=directory(expand("{result_dir}/{quantifier}/{{assembly}}-{{sample}}",**config))
             log:
@@ -298,7 +298,7 @@ elif config["quantifier"] == "kallistobus":
                 mem_gb=66,
             params:
                 basename=lambda wildcards, input: f"{input.basedir[0]}/{wildcards.assembly}",
-                barcode_arg=lambda wildcards, input: "-w " + input.barcodefile[0] if input.barcodefile else "", 
+                barcode_arg=lambda wildcards, input: ("-w " + input.barcodefile) if input.barcodefile else "", 
                 options=config.get("count")
             shell:
                 """


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
kb-python's barcode argument  is optional since it comes already pre-packed with several whitelists, such as for 10X, in case they are not provided by the user. Currently, the barcode argument is mandatory when running the scRNA seq workflow. 

**What did change**
The `barcodefile` argument is now optional.

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [ ] These changes are covered by the tests
