### PR TITLE
slop as param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ## [Unreleased]
 
+### Added
+
+- Added the slop parameter to the config.yaml of atac-seq and chip-seq workflows, just so they are more visible.
+
 ### Changed
 
 - Seq2science now makes a separate blacklist file per blacklist option (encode & mitochondria), so that e.g. RNA-seq and ATAC-seq workflows can be run in parallel and don't conflict on the blacklist.  

--- a/seq2science/workflows/atac_seq/config.yaml
+++ b/seq2science/workflows/atac_seq/config.yaml
@@ -39,6 +39,10 @@ peak_caller:
 #  genrich:
 #      -j -y -D -d 200 -q 0.05
 
+# how much should the peaks be extended around the summit for the count table
+# (e.g. 100 means a 200 bp wide peak)
+slop: 100
+
 ## differential accessibility analysis
 #contrasts:
 #  - 'biological_replicates_adult_embryo'

--- a/seq2science/workflows/chip_seq/config.yaml
+++ b/seq2science/workflows/chip_seq/config.yaml
@@ -36,6 +36,10 @@ peak_caller:
 #  genrich:
 #      -y -q 0.05
 
+# how much should the peaks be extended around the summit for the count table
+# (e.g. 100 means a 200 bp wide peak)
+slop: 100
+
 ## differential peak analysis
 #contrasts:
 #  - 'descriptive_name_all_HEL'


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
Small change where I add the `slop` param to the config.yaml. I feel like this is an important param that people should be aware of :) (slop is how much to extend each summit with for "unbiased" peak counts).

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
