### PR TITLE
libcrypto fix

### DIFF
--- a/seq2science/envs/gene_counts.yaml
+++ b/seq2science/envs/gene_counts.yaml
@@ -7,3 +7,4 @@ dependencies:
   - bioconda::htseq=0.12.4
   - bioconda::subread=2.0.1
   - bioconda::rseqc=4.0.0
+  - conda-forge::openssl=1.0.2p=h14c3975_1002 # infer_strandedness missing libcrypto


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
An issue with running seq2science, specifically in package infer_strandedness, error: "ImportError: libcrypto.so.1.0.0: cannot open shared object file: No such file or directory". 

**What did change**
We added a line in file gene_counts.yaml, where a new, specific version of openssl was installed. We tested it, and it worked. 


**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
