### PR TITLE
scale deeptools with n samples

### DIFF
--- a/seq2science/rules/qc.smk
+++ b/seq2science/rules/qc.smk
@@ -499,10 +499,10 @@ def get_plotCor_opts(lst):
     n = len(lst)
     if "--plotHeight" not in opts:
         # default: 9.5 cm
-        opts += f"--plotHeight {max(9.5, n*0.2)}"
+        opts += f" --plotHeight {max(9.5, n*0.3)}"
     if "--plotWidth" not in opts:
         # default: 11 cm
-        opts += f"--plotWidth {max(11, 1.5+n*0.2)}"
+        opts += f" --plotWidth {max(11, 1.5+n*0.3)}"
     return opts
 
 

--- a/seq2science/rules/qc.smk
+++ b/seq2science/rules/qc.smk
@@ -498,11 +498,11 @@ def get_plotCor_opts(lst):
     opts = config["deeptools_plotcorrelation"]
     n = len(lst)
     if "--plotHeight" not in opts:
-        # default: 9.5
-        opts += f"--plotHeight {min(9.5, n*0.2}"
+        # default: 9.5 cm
+        opts += f"--plotHeight {max(9.5, n*0.2)}"
     if "--plotWidth" not in opts:
-        # default: 11
-        opts += f"--plotWidth {min(11, 1.5+n*0.2}"
+        # default: 11 cm
+        opts += f"--plotWidth {max(11, 1.5+n*0.2)}"
     return opts
 
 

--- a/seq2science/rules/qc.smk
+++ b/seq2science/rules/qc.smk
@@ -529,7 +529,7 @@ rule plotCorrelation:
             if wildcards.method == "spearman"
             else '"Pearson Correlation of Read Counts"'
         ),
-        params=lambda input: get_plotCor_opts(input.bams),
+        params=lambda wildcards, input: get_plotCor_opts(input.bams),
     shell:
         """
         plotCorrelation --corData {input.cordata} --plotFile {output} -c {wildcards.method} \


### PR DESCRIPTION
**What problem is the PR solving**
with a large number of samples, this plot is very artistic, yet slightly less useful...
![image](https://user-images.githubusercontent.com/48289046/147105573-c720393d-4503-4f7b-95d5-ead11f39cb1e.png)

**What did change**
the size of the plot now scales with the number of bams. The new plot may not be any more readable in the MultiQC itself, but if the pixel density remains the same, you can now open it in a separate window and zoom in (similar to the DESeq2 heatmaps).

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [ ] I updated the CHANGELOG
- [ ] These changes are covered by the tests
