### PR TITLE
only use conda env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - raw/processed scRNA count tables are now stored and exported to SingleCellExperiment S4 objects instead of Seurat S4 objects 
 - moved scRNA post processing to separate module
 - export unspliced velocity counts to separate sce object
+- seq2science should be less susceptible to poor programming environment management
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - raw/processed scRNA count tables are now stored and exported to SingleCellExperiment S4 objects instead of Seurat S4 objects 
 - moved scRNA post processing to separate module
 - export unspliced velocity counts to separate sce object
-- seq2science should be less susceptible to poor programming environment management
+- seq2science should be less susceptible to poor programming environment management by using the conda-ecosystem-user-package-isolation package
 
 ### Removed
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -18,3 +18,4 @@ dependencies:
   - conda-forge::matplotlib=3.5.0
   - conda-forge::xdg=5.1.1
   - conda-forge::argcomplete=1.12.3
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/assembly_stats.yaml
+++ b/seq2science/envs/assembly_stats.yaml
@@ -8,4 +8,4 @@ dependencies:
   - bioconda::pyfaidx=0.6.3.1
   - conda-forge::matplotlib=3.4.3
   - bioconda::genomepy=0.10.0
-
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/bedtools.yaml
+++ b/seq2science/envs/bedtools.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::bedtools=2.29.2
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/bowtie2.yaml
+++ b/seq2science/envs/bowtie2.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::bowtie2=2.4.2
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/bwa.yaml
+++ b/seq2science/envs/bwa.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::bwa=0.7.17
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/bwamem2.yaml
+++ b/seq2science/envs/bwamem2.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::bwa-mem2=2.2.1
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/chipseeker.yaml
+++ b/seq2science/envs/chipseeker.yaml
@@ -8,3 +8,4 @@ dependencies:
   - bioconductor-chipseeker
   - bioconductor-do.db
   - bioconductor-genomicfeatures
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/cite-seq-count.yaml
+++ b/seq2science/envs/cite-seq-count.yaml
@@ -6,3 +6,4 @@ channels:
 dependencies: 
   - bioconda::cite-seq-count=1.4.4
   - conda-forge::python-levenshtein=0.12.0
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/conda-bot.yaml
+++ b/seq2science/envs/conda-bot.yaml
@@ -4,3 +4,4 @@ dependencies:
   - conda-forge::pygithub=1.43.6
   - pkgs/main::conda=4.8.0
   - conda-forge::pyyaml=5.2
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/decoy.yaml
+++ b/seq2science/envs/decoy.yaml
@@ -7,3 +7,4 @@ dependencies:
   - bioconda::bedtools=2.29.2
   - bioconda::mashmap=2.0
   - conda-forge::cpulimit=0.2
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/deeptools.yaml
+++ b/seq2science/envs/deeptools.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::deeptools=3.5.0
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/deseq2.yaml
+++ b/seq2science/envs/deseq2.yaml
@@ -19,3 +19,4 @@ dependencies:
   - conda-forge::r-pheatmap=1.0.12
   - conda-forge::r-pdftools=3.1
   - conda-forge::r-gridextra=2.3
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/dexseq.yaml
+++ b/seq2science/envs/dexseq.yaml
@@ -7,4 +7,4 @@ dependencies:
   - bioconda::bioconductor-dexseq=1.32.0
   - bioconda::pysam=0.16.0.1
   - bioconda::htseq=0.12.4
-  
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/dupradar.yaml
+++ b/seq2science/envs/dupradar.yaml
@@ -7,3 +7,4 @@ dependencies:
   - conda-forge::r-base=4.0.3
   - bioconda::bioconductor-dupradar=1.20.0
   - conda-forge::r-kernsmooth=2.23_18
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/edger.yaml
+++ b/seq2science/envs/edger.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::bioconductor-edger=3.28.0
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/fastp.yaml
+++ b/seq2science/envs/fastp.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::fastp=0.20.1
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/fastq-pair.yaml
+++ b/seq2science/envs/fastq-pair.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::fastq-pair=1.0
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/fastqc.yaml
+++ b/seq2science/envs/fastqc.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::fastqc=0.11.8
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/gene_counts.yaml
+++ b/seq2science/envs/gene_counts.yaml
@@ -8,3 +8,4 @@ dependencies:
   - bioconda::subread=2.0.1
   - bioconda::rseqc=4.0.0
   - conda-forge::openssl=1.0.2p=h14c3975_1002 # infer_strandedness missing libcrypto
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/genrich.yaml
+++ b/seq2science/envs/genrich.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::genrich=0.6.1
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/get_fastq.yaml
+++ b/seq2science/envs/get_fastq.yaml
@@ -7,3 +7,4 @@ dependencies:
   - pkgs/main::pigz=2.4
   - bioconda::sra-tools=2.11.0
   - bioconda::parallel-fastq-dump=0.6.7
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/gimme.yaml
+++ b/seq2science/envs/gimme.yaml
@@ -7,3 +7,4 @@ dependencies:
   - bioconda::gimmemotifs=0.15.1
   - bioconda::biofluff=3.0.3
   - conda-forge::pandas=1.1.5  # won't be necessary after https://github.com/vanheeringen-lab/gimmemotifs/issues/168 is fixed
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/hisat2.yaml
+++ b/seq2science/envs/hisat2.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::hisat2=2.2.1
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/hmmratac.yaml
+++ b/seq2science/envs/hmmratac.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::hmmratac=1.2.5
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/htmltable.yaml
+++ b/seq2science/envs/htmltable.yaml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - conda-forge::pretty_html_table=0.9.11
   - pandas=1.2.5
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/idr.yaml
+++ b/seq2science/envs/idr.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::idr=2.0.4.2
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/imagemick.yaml
+++ b/seq2science/envs/imagemick.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - conda-forge::imagemagick>=7.0
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/kallistobus.yaml
+++ b/seq2science/envs/kallistobus.yaml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - python>=3.7
   - bioconda::kb-python=0.26.4
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/khmer.yaml
+++ b/seq2science/envs/khmer.yaml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - bioconda::khmer=2.0
   - conda-forge::jq=1.6
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/macs2.yaml
+++ b/seq2science/envs/macs2.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::macs2=2.2.7
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/minimap2.yaml
+++ b/seq2science/envs/minimap2.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::minimap2=2.17
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/mtnucratio.yaml
+++ b/seq2science/envs/mtnucratio.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::mtnucratio=0.7
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/multiqc.yaml
+++ b/seq2science/envs/multiqc.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::multiqc=1.11
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/picard.yaml
+++ b/seq2science/envs/picard.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::picard=2.23.8
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/pysam.yaml
+++ b/seq2science/envs/pysam.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::pysam=0.15.3
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/pytxi.yaml
+++ b/seq2science/envs/pytxi.yaml
@@ -6,5 +6,6 @@ channels:
 dependencies:
   - genomepy=0.11.1
   - pip
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0
   - pip:
     - git+https://github.com/vanheeringen-lab/pytxi.git@v0.1.1

--- a/seq2science/envs/qnorm.yaml
+++ b/seq2science/envs/qnorm.yaml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - conda-forge::qnorm=0.4.0
   - conda-forge::pandas=1.1.2
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/salmon.yaml
+++ b/seq2science/envs/salmon.yaml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - bioconda::salmon=1.5.2
   - bioconda::gffread=0.12.1
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/sambamba.yaml
+++ b/seq2science/envs/sambamba.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::sambamba=0.7.0
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/samtools.yaml
+++ b/seq2science/envs/samtools.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::samtools=1.14
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/sce.yaml
+++ b/seq2science/envs/sce.yaml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - bioconda::bioconductor-singlecelltk=2.4.0
   - conda-forge::r-matrix=1.4.0 
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/sctk.yaml
+++ b/seq2science/envs/sctk.yaml
@@ -10,6 +10,7 @@ dependencies:
   - anaconda::six=1.16.0
   - anaconda::numpy=1.21.5
   - conda-forge::r-kableextra=1.3.4
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0
   - pip:
     - scrublet==0.2.3
     - scanpy==1.8.2

--- a/seq2science/envs/snaptools.yaml
+++ b/seq2science/envs/snaptools.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::snaptools=1.4.8
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/star.yaml
+++ b/seq2science/envs/star.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::star=2.7.6a
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/subread.yaml
+++ b/seq2science/envs/subread.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::subread=1.6.4
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/trimgalore.yaml
+++ b/seq2science/envs/trimgalore.yaml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - bioconda::trim-galore=0.6.4
   - conda-forge::cpulimit=0.2
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/tximeta.yaml
+++ b/seq2science/envs/tximeta.yaml
@@ -11,3 +11,4 @@ dependencies:
   - bioconda::bioconductor-singlecellexperiment=1.14.1
   - conda-forge::r-tidyverse=1.3.1
   - conda-forge::r-readr=1.4.0
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/ucsc.yaml
+++ b/seq2science/envs/ucsc.yaml
@@ -13,3 +13,4 @@ dependencies:
   - bioconda::ucsc-hggcpercent=377
   - bioconda::ucsc-ixixx=377
   - bioconda::ucsc-wigtobigwig=377
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/upset.yaml
+++ b/seq2science/envs/upset.yaml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - conda-forge::upsetplot=0.6.0
+  - conda-forge::conda-ecosystem-user-package-isolation=1.0


### PR DESCRIPTION
**What problem is the PR solving / What's new?**

I've tried updating our bioconda recipe to set PYTHONUSERBASE so we wouldn't use local python packages. I've come across an even better solution! There is a package that does that for us! This recipe sets the PYTHONUSERBASE, but even better, it does the same stuff for R related things. This means that people should be able to fuck up as much as they want, but it shouldn't intervene with seq2science anymore!!

~~I am just not sure if it also translates to the environments made from this environment. If not then I'll add this to **every** environment.~~ I just got an answer from **dpryan** and he says it won't help with downstream environments, so I guess I'll have to add it to each environment :smile: 

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
