### PR TITLE
allow samples.tsvs with multiple assemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 ### Added
 
 - seq2science specific lockexception and cleanup metadata errors
+- `deseq2science` now accepts the optional argument `--assembly`, which can be used if the samples.tsv contains >1 assembly to specify which one is used.
+  - By default, the first assembly is used (same as before)
 
 ### Changed
 
 - rules that download something get re-tried once, in case internet is unstable
+- `deseq2science` now has a clear separation between positional and optional arguments
 
 ### Fixed
 

--- a/seq2science/cli.py
+++ b/seq2science/cli.py
@@ -242,10 +242,19 @@ def deseq2science_parser():
         action='store_true',
         help="use if the counts are Single Cell data",
     )
+
     # go to the docs!
+    class DocAction(argparse._StoreTrueAction):  # noqa
+        def __call__(self, parser, namespace, values, option_string=None):  # noqa
+            import webbrowser
+            url = "https://vanheeringen-lab.github.io/seq2science/content/DESeq2.html"
+            if not webbrowser.open(url):
+                print(url)
+            os._exit(0)  # noqa
+
     parser.add_argument(
         "--docs",
-        action='store_true',
+        action=DocAction,
         help="open de DESeq2 wrapper documentation (with examples!)",
     )
     argcomplete.autocomplete(parser)
@@ -701,13 +710,6 @@ def run_snakemake(workflow, **config):
 
 
 def _deseq(args, base_dir):
-    # docs
-    if args.docs is True:
-        url = "https://vanheeringen-lab.github.io/seq2science/content/DESeq2.html"
-        if not webbrowser.open(url):
-            print(url)
-        return
-
     import hashlib
     import subprocess as sp
 

--- a/seq2science/cli.py
+++ b/seq2science/cli.py
@@ -216,44 +216,39 @@ def deseq2science_parser():
     )
     # DESeq2 wrapper arguments
     parser.add_argument(
-        "-d",
-        "--design",
-        default="",  # must be an empty string for R's arg checking + docs CLI argument
+        "design",
         help="design contrast (e.g. column_knockouts_controls)",
     )
     parser.add_argument(
-        "-s",
-        "--samples",
-        default="",  # must be an empty string for R's arg checking + docs CLI argument
+        "samples",
         help="samples.tsv with a column containing the contrast arguments "
              "(sample order consistent with the counts.tsv)",
     )
     parser.add_argument(
-        "-c",
-        "--counts",
-        default="",  # must be an empty string for R's arg checking + docs CLI argument
+        "counts",
         help="counts.tsv(.gz) (sample order consistent with the samples.tsv)",
     )
     parser.add_argument(
-        "-o",
-        "--outdir",
-        default="",  # must be an empty string for R's arg checking + docs CLI argument
+        "outdir",
         help="output directory",
     )
     parser.add_argument(
-        "-sc",
+        "--assembly",
+        metavar="NAME",
+        help="specify the assembly (if the samples.tsv contains >1)",
+    )
+    parser.add_argument(
         "--single-cell",
         action='store_true',
-        default=False,
         help="use if the counts are Single Cell data",
     )
+    # go to the docs!
     parser.add_argument(
         "--docs",
         action='store_true',
         help="open de DESeq2 wrapper documentation (with examples!)",
     )
     argcomplete.autocomplete(parser)
-
     return parser
 
 
@@ -713,11 +708,6 @@ def _deseq(args, base_dir):
             print(url)
         return
 
-    # insufficient args
-    if not all(len(a) > 0 for a in [args.counts, args.design, args.outdir, args.samples]):
-        logger.info("4 arguments expected: contrast, samples_file, counts_file and outdir.")
-        return
-
     import hashlib
     import subprocess as sp
 
@@ -756,7 +746,8 @@ def _deseq(args, base_dir):
     # we don't even need to activate the env
     rscript = os.path.join(env_prefix, "bin", "Rscript")
     script = os.path.join(base_dir, "scripts", "deseq2", "deseq2.R")
-    cmd = f"{rscript} {script} {args.design} {args.samples} {args.counts} {args.outdir} {args.single_cell}"
+    cmd = f"{rscript} {script} {args.design} {args.samples} {args.counts} {args.outdir} " \
+          f"{args.assembly} {args.single_cell}"
     subprocess_run(cmd)
 
     # example command:

--- a/seq2science/scripts/deseq2/run_as_standalone.R
+++ b/seq2science/scripts/deseq2/run_as_standalone.R
@@ -17,15 +17,16 @@ for (pkg in required_packages){
 }
 
 # parse arguments
-if (!length(args) %in% c(4,5)) {
-  cat("Four arguments expected: contrast, samples_file, counts_file and outdir. Optional: single_cell.")
+if (!length(args) %in% c(4,5,6)) {
+  cat("Four arguments expected: contrast, samples_file, counts_file and outdir. Optional: assembly, single_cell.")
   quit(save = "no" , status = 0)
 }
 contrast     <- args[1]
 samples_file <- args[2]
 counts_file  <- args[3]
 out_dir      <- args[4]
-single_cell  <- ifelse(length(args)==5, as.logical(args[5]), FALSE)
+assembly     <- args[5]
+single_cell  <- ifelse(length(args)==6, as.logical(args[6]), FALSE)
 
 if (!length(strsplit(contrast, '_')[[1]]) >= 3){
   cat("Contrast must contain a column name and two fields separated with an underscore (_).  \n\n")
@@ -48,12 +49,12 @@ if (!dir.exists(out_dir)){
 
 # variables required in the core script
 samples            <- read.delim(samples_file, sep = "\t", na.strings = "", comment.char = "#", stringsAsFactors = F, row.names = "sample", check.names = F)
-replicates         <- "technical_replicates" %in% colnames(samples)  # always merge replicates if "technical_replicates" exists
-assembly           <- samples$assembly[1]                            # always use the first assembly
-mtp                <- "BH"                                           # \
-fdr                <- 0.1                                            #  |-default options only
-se                 <- "apeglm"                                       # /
-salmon             <- FALSE                                          # only work with counts data
+replicates         <- "technical_replicates" %in% colnames(samples)                          # always merge replicates if "technical_replicates" exists
+assembly           <- ifelse(assembly %in% samples$assembly, assembly, samples$assembly[1])  # use the first assembly
+mtp                <- "BH"                                                                   # \
+fdr                <- 0.1                                                                    #  |-default options only
+se                 <- "apeglm"                                                               # /
+salmon             <- FALSE                                                                  # only work with counts data
 threads            <- 1
 output             <- file.path(out_dir, paste0(assembly, "-", contrast, ".diffexp.tsv"))
 output_ma_plot     <- sub(".diffexp.tsv", ".ma_plot.png", output)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -268,10 +268,10 @@ if [ $1 = "deseq2science" ]; then
   rm -rf $outdir
 
   deseq2science \
-  -d batch+condition_day2_day0 \
-  -s tests/deseq2/rna/samples.tsv \
-  -c tests/deseq2/rna/counts/GRCh38.p13-counts.tsv \
-  -o $outdir
+  batch+condition_day2_day0 \
+  tests/deseq2/rna/samples.tsv \
+  tests/deseq2/rna/counts/GRCh38.p13-counts.tsv \
+  $outdir
 
   # very basic test: check if all output files are generated
   fcount=$(ls -1q $outdir | wc -l)


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
When using `deseq2science`, you can now optionally specify which assembly is being used.
By default the first assembly is expected (as it was before).

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
