### PR TITLE
fix blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,8 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - fixed custom assembly extensions (e.g. ERCC spike-ins) for scATAC-seq and scRNA-seq
 - profiles work again
 - `deseq2science` now has a clear separation between positional and optional arguments
-
-### Fixed
-
 - fixed custom assembly extentions (e.g. ERCC spike-ins) for scATAC-seq and scRNA-seq
+- issue with blacklist bed containing more than 3 columns
 
 ## [0.9.1] - 2022-05-10
 

--- a/seq2science/scripts/genomepy/get_genome_blacklist.py
+++ b/seq2science/scripts/genomepy/get_genome_blacklist.py
@@ -28,6 +28,15 @@ with open(logfile, "w") as log:
         plugins["blacklist"].after_genome_download(genome)
 
         # touch the file if no blacklist was available
-        if not os.path.exists(output):
+        if os.path.exists(output):
+            with open(output, "r") as f:
+                lines = f.readlines()
+
+            # only keep first three columns
+            lines = ["\t".join(line.split("\t")[:3]) for line in lines]
+
+            with open(output, "w") as f:
+                f.write("\n".join(lines) + "\n")
+        else:
             with open(output, 'w'):
                 os.utime(output, None)


### PR DESCRIPTION
**What problem is the PR solving / What's new?**

The `GRCm38.p6` blacklist somehow now has 4 columns, but this doesn't work with how we remove the blacklist in combination with removal of mitochondrial reads. So we just chop off the fourth!

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
