### PR TITLE
fix ena urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 - no longer writes multiqc filenames to an intermediate file
 
+### Fixed
+
+- downloading fastq from ena directly fixed 
+
 ### [0.9.4] - 2022-07-07
 
 ### Fixed

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
   - conda-forge::pandas_schema=0.3.5
   - conda-forge::pandas=1.3.2
   - bioconda::trackhub=0.1.2019.12.24
-  - bioconda::pysradb=1.4.1
+  - bioconda::pysradb=1.4.2
   - conda-forge::matplotlib=3.5.2
   - conda-forge::xdg=5.1.1
   - conda-forge::argcomplete=2.0.0


### PR DESCRIPTION
**What problem is the PR solving / What's new?**

The ENA url was missing, the newest update should fix that

https://github.com/saketkc/pysradb/issues/163#issuecomment-1188677687

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
