### PR TITLE
Update kallistobus.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 ### Changed
 
 - no longer writes multiqc filenames to an intermediate file
+- Updated kb-python to 0.27.3
 
 ### Fixed
 

--- a/seq2science/envs/kallistobus.yaml
+++ b/seq2science/envs/kallistobus.yaml
@@ -5,5 +5,6 @@ channels:
   - defaults
 dependencies:
   - python>=3.7
-  - bioconda::kb-python=0.26.4
+  - bioconda::kb-python=0.27.3
+  - conda-forge::numpy=1.21.5
   - conda-forge::conda-ecosystem-user-package-isolation=1.0


### PR DESCRIPTION
Update kb-python

Update kb-python to 0.27.3. Numpy version freeze is required for Numba dependency.

**Checklist**
- [x] I made a PR to develop (not master)
- [x] I updated the CHANGELOG
