### PR TITLE
Update deeptools.yaml

### DIFF
--- a/seq2science/envs/deeptools.yaml
+++ b/seq2science/envs/deeptools.yaml
@@ -4,5 +4,5 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::deeptools=3.5.0
+  - bioconda::deeptools=3.5.1
   - conda-forge::conda-ecosystem-user-package-isolation=1.0


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
```
Error in rule plotHeatmap_peak:

    jobid: 34

    output: /var/lib/jenkins/workspace/seq2science_PR-896/tests/local_test_results/qc/plotHeatmap_peaks/N20000-fr3_custom-deepTools_macs2_heatmap_mqc.png

    log: /var/lib/jenkins/workspace/seq2science_PR-896/tests/local_test_results/log/plotHeatmap_peaks/fr3_custom-macs2_N20000.log (check log file(s) for error message)

    conda-env: /var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b

    shell:

        

        plotHeatmap --matrixFile /var/lib/jenkins/workspace/seq2science_PR-896/tests/local_test_results/qc/computeMatrix_peak/fr3_custom-macs2_N20000.mat.gz --outFileName /var/lib/jenkins/workspace/seq2science_PR-896/tests/local_test_results/qc/plotHeatmap_peaks/N20000-fr3_custom-deepTools_macs2_heatmap_mqc.png --kmeans 6 --xAxisLabel "Summit distance (bp)" --startLabel="-1000" --endLabel=1000 > /var/lib/jenkins/workspace/seq2science_PR-896/tests/local_test_results/log/plotHeatmap_peaks/fr3_custom-macs2_N20000.log 2>&1

        

        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)

Logfile /var/lib/jenkins/workspace/seq2science_PR-896/tests/local_test_results/log/plotHeatmap_peaks/fr3_custom-macs2_N20000.log:

*Warning* For clustering nan values have to be replaced by zeros 

Traceback (most recent call last):

  File "/var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b/bin/plotHeatmap", line 12, in <module>

    main(args)

  File "/var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b/lib/python3.10/site-packages/deeptools/plotHeatmap.py", line 874, in main

    plotMatrix(hm,

  File "/var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b/lib/python3.10/site-packages/deeptools/plotHeatmap.py", line 770, in plotMatrix

    plt.savefig(outFileName, bbox_inches='tight', pdd_inches=0, dpi=dpi, format=image_format)

  File "/var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b/lib/python3.10/site-packages/matplotlib/pyplot.py", line 942, in savefig

    res = fig.savefig(*args, **kwargs)

  File "/var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b/lib/python3.10/site-packages/matplotlib/figure.py", line 3272, in savefig

    self.canvas.print_figure(fname, **kwargs)

  File "/var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b/lib/python3.10/site-packages/matplotlib/backend_bases.py", line 2338, in print_figure

    result = print_method(

  File "/var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b/lib/python3.10/site-packages/matplotlib/backend_bases.py", line 2204, in <lambda>

    print_method = functools.wraps(meth)(lambda *args, **kwargs: meth(

  File "/var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 385, in wrapper

    arguments = signature.bind(*inner_args, **inner_kwargs).arguments

  File "/var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b/lib/python3.10/inspect.py", line 3179, in bind

    return self._bind(args, kwargs)

  File "/var/lib/jenkins/workspace/seq2science_PR-896/miniconda/envs/s2s/lib/python3.8/site-packages/seq2science/.snakemake/204d615678b364e822f2ba70a56c9c8b/lib/python3.10/inspect.py", line 3168, in _bind

    raise TypeError(

TypeError: got an unexpected keyword argument 'pdd_inches'

```

**What did change**
Seems this typo is found in deeptools 3.5.0, but fixed in 3.5.1. Why on earth we never had this error before is beyond me.

**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [ ] I updated the CHANGELOG
- [x] These changes are covered by the tests
