### PR TITLE
force assembly hub flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ## [Unreleased]
 
+### Added
+
+- a `force_assembly_hub` flag to make an ucsc assembly hub even though a trackhub already exists
+
 ## [0.9.7] - 2023-01-03
 
 ### Added

--- a/seq2science/rules/trackhub.smk
+++ b/seq2science/rules/trackhub.smk
@@ -230,9 +230,11 @@ if config.get("create_trackhub"):
         # if not found, return the original name
         return False, assembly
 
-
-    ucsc_names = {a: get_ucsc_name(a) for a in ALL_ASSEMBLIES}
-
+    # check if trackhubs are available on ucsc (in case we dont force an assembly hub)
+    if config.get("force_assembly_hub", False):
+        ucsc_names = {a: (False, a) for a in ALL_ASSEMBLIES}
+    else:
+        ucsc_names = {a: get_ucsc_name(a) for a in ALL_ASSEMBLIES}
 
     def get_defaultpos(sizefile):
         # extract a default position spanning the first scaffold/chromosome in the sizefile.

--- a/seq2science/schemas/config/trackhub.schema.yaml
+++ b/seq2science/schemas/config/trackhub.schema.yaml
@@ -22,3 +22,8 @@ properties:
   deeptools_bamcoverage:
     description: flags for bam to bigwig conversions with deeptools bamCoverage
     default: '--normalizeUsing BPM --binSize 1'  # Bins Per Million mapped reads, same as TPM in RNA-seq
+
+  force_assembly_hub:
+    description: whether an assembly hub should be made even though the assembly is supported by ucsc. Sometimes e.g. chromosomes have different names (chr1 vs 1) which makes the trackhub not display the data properly. Forcing an assembly hub can help in these cases.
+    default: false
+    type: boolean


### PR DESCRIPTION
**What problem is the PR solving / What's new?**

Had some issues last week with an assembly being recognized as trackhub, but somehow didnt work on ucsc. All tracks would report no data. Perhaps issue with chromosome names or sth. By setting `force_assembly_hub: true` you can still make it work :smile: 

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [ ] These changes are covered by the tests
