### PR TITLE
ASAP to trimmed FASTQs

### DIFF
--- a/seq2science/rules/alignment.smk
+++ b/seq2science/rules/alignment.smk
@@ -40,7 +40,7 @@ if config["aligner"] == "bowtie2":
             expand("{log_dir}/{aligner}_index/{{assembly}}.log", **config),
         benchmark:
             expand("{benchmark_dir}/{aligner}_index/{{assembly}}.benchmark.txt", **config)[0]
-        priority: 1
+        priority: 10
         threads: 4
         conda:
             "../envs/bowtie2.yaml"
@@ -74,7 +74,6 @@ if config["aligner"] == "bowtie2":
                 else ["-1", input.reads[0], "-2", input.reads[1]]
             ),
             params=config["align"],
-        priority: 0
         threads: get_aligner_threads()
         conda:
             "../envs/bowtie2.yaml"
@@ -101,7 +100,7 @@ elif config["aligner"] == "bwa-mem":
         params:
             prefix="{genome_dir}/{{assembly}}/index/{aligner}/{{assembly}}".format(**config),
             params=config["index"],
-        priority: 1
+        priority: 10
         resources:
             mem_gb=5,
         conda:
@@ -132,7 +131,6 @@ elif config["aligner"] == "bwa-mem":
             params=config["align"],
         resources:
             mem_gb=13,
-        priority: 0
         threads: get_aligner_threads()
         conda:
             "../envs/bwa.yaml"
@@ -158,7 +156,7 @@ elif config["aligner"] == "bwa-mem2":
             expand("{benchmark_dir}/{aligner}_index/{{assembly}}.benchmark.txt", **config)[0]
         params:
             prefix="{genome_dir}/{{assembly}}/index/{aligner}/{{assembly}}".format(**config),
-        priority: 1
+        priority: 10
         resources:
             mem_gb=40,
         conda:
@@ -189,7 +187,6 @@ elif config["aligner"] == "bwa-mem2":
             params=config["align"],
         resources:
             mem_gb=40,
-        priority: 0
         threads: get_aligner_threads()
         conda:
             "../envs/bwamem2.yaml"
@@ -216,7 +213,7 @@ elif config["aligner"] == "hisat2":
         benchmark:
             expand("{benchmark_dir}/{aligner}_index/{{assembly}}.benchmark.txt", **config)[0]
         message: EXPLAIN["hisat_splice_aware"]
-        priority: 1
+        priority: 10
         threads: 8
         resources:
             mem_gb=200,  # yes really
@@ -248,7 +245,7 @@ elif config["aligner"] == "hisat2":
             expand("{log_dir}/{aligner}_index/{{assembly}}.log", **config),
         benchmark:
             expand("{benchmark_dir}/{aligner}_index/{{assembly}}.benchmark.txt", **config)[0]
-        priority: 1
+        priority: 10
         threads: 4
         resources:
             mem_gb=8,
@@ -291,7 +288,6 @@ elif config["aligner"] == "hisat2":
                 else ["-1", input.reads[0], "-2", input.reads[1]]
             ),
             params=config["align"],
-        priority: 0
         threads: get_aligner_threads()
         conda:
             "../envs/hisat2.yaml"
@@ -317,7 +313,7 @@ elif config["aligner"] == "minimap2":
             expand("{benchmark_dir}/{aligner}_index/{{assembly}}.benchmark.txt", **config)[0]
         params:
             config["index"],
-        priority: 1
+        priority: 10
         threads: 3
         resources:
             mem_gb=12,
@@ -347,7 +343,6 @@ elif config["aligner"] == "minimap2":
         params:
             # input=lambda wildcards, input: input.reads if config["layout"][wildcards.sample] == "SINGLE" else input.reads[0:2],
             params=config["align"],
-        priority: 0
         threads: get_aligner_threads()
         resources:
             mem_gb=20,
@@ -388,7 +383,7 @@ elif config["aligner"] == "star":
             expand("{benchmark_dir}/{aligner}_index/{{assembly}}.benchmark.txt", **config)[0]
         params:
             config["index"],
-        priority: 1
+        priority: 10
         threads: 10
         resources:
             mem_gb=41,
@@ -451,7 +446,6 @@ elif config["aligner"] == "star":
             if SAMPLEDICT[wildcards.sample]["layout"] == "SINGLE"
             else input.reads[0:2],
             params=config["align"],
-        priority: 0
         threads: get_aligner_threads()
         resources:
             mem_gb=30,
@@ -485,7 +479,6 @@ rule samtools_presort:
         expand("{log_dir}/samtools_presort/{{assembly}}-{{sample}}.log", **config),
     benchmark:
         expand("{benchmark_dir}/samtools_presort/{{assembly}}-{{sample}}.benchmark.txt", **config)[0]
-    priority: 0
     threads: get_sorter_threads()
     resources:
         mem_gb=config["bam_sort_mem"],

--- a/seq2science/rules/gene_quantification.smk
+++ b/seq2science/rules/gene_quantification.smk
@@ -23,7 +23,7 @@ if config["quantifier"] == "salmon":
         log:
             expand("{log_dir}/quantification/{{assembly}}.transcripts.log", **config),
         conda: "../envs/salmon.yaml"
-        priority: 1
+        priority: 10
         shell:
             """
             gffread -w {output} -g {input.fa} {input.gtf} > {log} 2>&1
@@ -49,7 +49,7 @@ if config["quantifier"] == "salmon":
         conda: "../envs/decoy.yaml"
         threads: 40
         resources: mem_gb=64,
-        priority: 1
+        priority: 10
         shell:
             ("cpulimit --include-children -l {threads}00 --" if config.get("cpulimit", True) else "")+
             """\
@@ -109,7 +109,7 @@ if config["quantifier"] == "salmon":
             ),
             params=config["quantifier_index"],
         conda: "../envs/salmon.yaml"
-        priority: 1
+        priority: 10
         threads: 10
         resources: mem_gb=9,  # fully decoy aware
         shell:
@@ -197,7 +197,7 @@ elif  "scrna_seq" == WORKFLOW:
             intermediates1=temp(expand("{fastq_clean_dir}/{{sample}}_clean_{fqext}.{fqsuffix}", **config)),
             intermediates2=temp(expand("{fastq_clean_dir}/{{sample}}_clean_{fqext}.{fqsuffix}.single.fq", **config)),
             intermediates3=temp(expand("{fastq_clean_dir}/{{sample}}_clean_{fqext}.{fqsuffix}.paired.fq", **config)),
-        priority: 1
+        priority: 3
         log:
             expand("{log_dir}/fastq_pair/{{sample}}.log", **config),
         benchmark:
@@ -254,7 +254,7 @@ elif  "scrna_seq" == WORKFLOW:
                 expand("{log_dir}/kallistobus_index/{{assembly}}.log", **config),
             benchmark:
                 expand("{benchmark_dir}/kallistobus_index/{{assembly}}.benchmark.txt", **config)[0]
-            priority: 1
+            priority: 10
             conda:
                 "../envs/kallistobus.yaml"
             resources:
@@ -299,7 +299,7 @@ elif  "scrna_seq" == WORKFLOW:
             params:
                 basename=lambda wildcards, output: f"{output[0]}/{wildcards.assembly}",
                 options=config.get("ref"),
-            priority: 1
+            priority: 10
             shell:
                 """
                 mkdir -p {output}
@@ -334,7 +334,6 @@ elif  "scrna_seq" == WORKFLOW:
                 expand("{log_dir}/kallistobus_count/{{assembly}}-{{sample}}.log", **config),
             benchmark:
                 expand("{benchmark_dir}/kallistobus_count/{{assembly}}-{{sample}}.benchmark.txt", **config)[0]
-            priority: 1
             conda:
                 "../envs/kallistobus.yaml"
             threads: 8
@@ -387,7 +386,6 @@ elif  "scrna_seq" == WORKFLOW:
                 expand("{log_dir}/citeseqcount/{{assembly}}-{{sample}}.log", **config),
             benchmark:
                 expand("{benchmark_dir}/citeseqcount/{{assembly}}-{{sample}}.benchmark.txt", **config)[0]
-            priority: 1
             conda:
                 "../envs/cite-seq-count.yaml"
             threads: 8

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -20,6 +20,7 @@ rule run2sra:
     message: EXPLAIN["run2sra"]
     resources:
         parallel_downloads=1,
+    priority: -1  # less priority than sra2fastq, to conserve disk space.
     params:
         outdir=lambda wildcards: f"{config['sra_dir']}/{wildcards.run}",
     conda:
@@ -307,6 +308,7 @@ rule runs2sample:
         expand("{log_dir}/run2sample/{{sample}}{{suffix}}.log", **config),
     benchmark:
         expand("{benchmark_dir}/run2sample/{{sample}}{{suffix}}.benchmark.txt", **config)[0]
+    priority: 1  # higher priority to conserve disk space
     wildcard_constraints:
         sample="|".join(public_samples) if len(public_samples) > 0 else "$a",
     run:

--- a/seq2science/rules/get_fastq.smk
+++ b/seq2science/rules/get_fastq.smk
@@ -20,7 +20,6 @@ rule run2sra:
     message: EXPLAIN["run2sra"]
     resources:
         parallel_downloads=1,
-    priority: -1  # less priority than sra2fastq, to conserve disk space.
     params:
         outdir=lambda wildcards: f"{config['sra_dir']}/{wildcards.run}",
     conda:
@@ -92,6 +91,7 @@ rule sra2fastq_SE:
     threads: 8
     conda:
         "../envs/get_fastq.yaml"
+    priority: 1
     retries: 2
     shell:
         """
@@ -134,6 +134,7 @@ rule sra2fastq_PE:
         run="|".join(SRA_PAIRED_END) if len(SRA_PAIRED_END) else "$a",  # only try to dump (paired-end) SRA samples
     conda:
         "../envs/get_fastq.yaml"
+    priority: 1
     retries: 2
     shell:
         """
@@ -176,6 +177,7 @@ rule ena2fastq_SE:
         expand("{benchmark_dir}/ena2fastq_SE/{{run}}.benchmark.txt", **config)[0]
     wildcard_constraints:
         run="|".join(ENA_SINGLE_END) if len(ENA_SINGLE_END) else "$a",
+    priority: 1
     retries: 2
     run:
         shell("mkdir -p {config[fastq_dir]}/tmp/ >> {log} 2>&1")
@@ -204,6 +206,7 @@ rule ena2fastq_PE:
         expand("{benchmark_dir}/ena2fastq_PE/{{run}}.benchmark.txt", **config)[0]
     wildcard_constraints:
         run="|".join(ENA_PAIRED_END) if len(ENA_PAIRED_END) else "$a",
+    priority: 1
     retries: 2
     run:
         shell("mkdir -p {config[fastq_dir]}/tmp >> {log} 2>&1")
@@ -239,6 +242,7 @@ rule gsa2fastq_SE:
         expand("{benchmark_dir}/gsa2fastq_SE/{{run}}.benchmark.txt", **config)[0]
     wildcard_constraints:
         run="|".join(GSA_SINGLE_END) if len(GSA_SINGLE_END) else "$a",
+    priority: 1
     retries: 2
     run:
         shell("mkdir -p {config[fastq_dir]}/tmp/ >> {log} 2>&1")
@@ -265,6 +269,7 @@ rule gsa2fastq_PE:
         expand("{benchmark_dir}/gsa2fastq_PE/{{run}}.benchmark.txt", **config)[0]
     wildcard_constraints:
         run="|".join(GSA_PAIRED_END) if len(GSA_PAIRED_END) else "$a",
+    priority: 1
     retries: 2
     run:
         shell("mkdir -p {config[fastq_dir]}/tmp >> {log} 2>&1")
@@ -308,7 +313,7 @@ rule runs2sample:
         expand("{log_dir}/run2sample/{{sample}}{{suffix}}.log", **config),
     benchmark:
         expand("{benchmark_dir}/run2sample/{{sample}}{{suffix}}.benchmark.txt", **config)[0]
-    priority: 1  # higher priority to conserve disk space
+    priority: 2
     wildcard_constraints:
         sample="|".join(public_samples) if len(public_samples) > 0 else "$a",
     run:

--- a/seq2science/rules/get_genome.smk
+++ b/seq2science/rules/get_genome.smk
@@ -26,7 +26,7 @@ rule get_genome:
     resources:
         parallel_downloads=1,
         genomepy_downloads=1,
-    priority: 1
+    priority: 10
     retries: 2
     script:
         f"{config['rule_dir']}/../scripts/genomepy/get_genome.py"
@@ -64,7 +64,7 @@ rule get_genome_blacklist:
     resources:
         parallel_downloads=1,
         genomepy_downloads=1,
-    priority: 1
+    priority: 10
     retries: 2
     script:
         f"{config['rule_dir']}/../scripts/genomepy/get_genome_blacklist.py"
@@ -91,7 +91,7 @@ rule get_genome_annotation:
     resources:
         parallel_downloads=1,
         genomepy_downloads=1,
-    priority: 1
+    priority: 10
     retries: 2
     script:
         f"{config['rule_dir']}/../scripts/genomepy/get_genome_annotation.py"

--- a/seq2science/rules/qc_scRNA.smk
+++ b/seq2science/rules/qc_scRNA.smk
@@ -25,7 +25,6 @@ rule export_sce_obj:
         ),
     log:
         expand("{log_dir}/scrna-preprocess/{quantifier}/raw/{{assembly}}-{{sample}}_raw_sce.log", **config),
-    priority: 1
     conda:
         "../envs/sce.yaml"
     params:
@@ -56,7 +55,6 @@ rule sctk_qc:
         ),
     log:
         expand("{log_dir}/scrna-preprocess/{quantifier}/sctk/{{assembly}}-{{sample}}_sctk.log", **config),
-    priority: 1
     conda:
         "../envs/sctk.yaml"
     threads: 4

--- a/seq2science/rules/trimming.smk
+++ b/seq2science/rules/trimming.smk
@@ -72,6 +72,7 @@ if config["trimmer"] == "trimgalore":
         conda:
             "../envs/trimgalore.yaml"
         threads: 6
+        priority: 3
         message: EXPLAIN["trimgalore_SE"]
         log:
             expand("{log_dir}/trimgalore_SE/{{sample}}.log", **config),
@@ -111,6 +112,7 @@ if config["trimmer"] == "trimgalore":
         conda:
             "../envs/trimgalore.yaml"
         threads: 6
+        priority: 3
         message: EXPLAIN["trimgalore_PE"]
         log:
             expand("{log_dir}/trimgalorePE/{{sample}}.log", **config),
@@ -155,6 +157,7 @@ elif config["trimmer"] == "fastp":
         conda:
             "../envs/fastp.yaml"
         threads: 4
+        priority: 3
         message: EXPLAIN["fastp_SE"]
         wildcard_constraints:
             sample="|".join(all_single_samples) if len(all_single_samples) else "$a"
@@ -187,6 +190,7 @@ elif config["trimmer"] == "fastp":
         conda:
             "../envs/fastp.yaml"
         threads: 4
+        priority: 3
         wildcard_constraints:
             sample="|".join(all_paired_samples) if len(all_paired_samples) else "$a"
         message: EXPLAIN["fastp_PE"]


### PR DESCRIPTION
Prioritize getting trimmed fastqs, allowing intermediate files to be deleted. After reaching trimmed fastqs, file sizes balloon, so this should minimize disk usage.

I rewrote some other priorities as well, since generating aligner indexes remains a big bottleneck.