### PR TITLE
update prefetch

### DIFF
--- a/seq2science/envs/get_fastq.yaml
+++ b/seq2science/envs/get_fastq.yaml
@@ -2,10 +2,8 @@ name: get_fastq
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - pkgs/main::pigz=2.4
-  - bioconda::sra-tools=2.11.0
+  - bioconda::sra-tools=3.0.3
   - bioconda::parallel-fastq-dump=0.6.7
   - conda-forge::flock=0.2.3
   - conda-forge::conda-ecosystem-user-package-isolation=1.0


### PR DESCRIPTION
Nope, you really can't pipe `prefetch` output. But we can update the tool! Prefetch received bugfixes and can now accept and unlimited max-size. And we can clean up the yaml a bit (pigz isn't used anymore?)