### PR TITLE
faster envs

### DIFF
--- a/.github/workflows/continuousdeployment.yml
+++ b/.github/workflows/continuousdeployment.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
@@ -25,7 +25,7 @@ jobs:
 
     - name: Get Changelog Entry
       id: changelog_reader
-      uses: mindsers/changelog-reader-action@v1.3.1
+      uses: mindsers/changelog-reader-action@v2
       with:
         version: ${{ steps.tag_name.outputs.current_version }}
         path: ./CHANGELOG.md

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,16 +25,26 @@ jobs:
           mamba activate
 
           # load channels
-          $CONDA/bin/conda config --add channels defaults
           $CONDA/bin/conda config --add channels bioconda
           $CONDA/bin/conda config --add channels conda-forge
-          rm /usr/share/miniconda/pkgs/cache/*.json  # see mamba/issues/488
           
-          # install seq2science env and docs env
-          mamba env create --name seq2science --file requirements.yaml
+          # install seq2science with added docs requirements
+          declare -a requirements=(
+            "graphviz>=7"
+            "importlib_metadata=4.11.4"
+            "m2r2>=0.3.3"
+            "networkx>=3"
+            "sphinx>=6"
+            "sphinx_rtd_theme>=1.2"
+            "sphinx-argparse>=0.4"
+          )
+          cp requirements.yaml doc_reqs.yaml
+          for pkg in "${requirements[@]}"; do
+            echo "  - conda-forge::${pkg}" >> doc_reqs.yaml
+          done
+          mamba env create --name seq2science --file doc_reqs.yaml
+          rm doc_reqs.yaml
           mamba activate seq2science
-          VERSION=$(cat requirements.yaml | grep mamba | cut -d '=' -f2)
-          mamba install m2r2 sphinx sphinx_rtd_theme sphinx-argparse graphviz networkx importlib_metadata=4.11.4 mamba=$VERSION
           pip3 install .
 
           # make the docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - clear error message when downloading single-end data annotated as paired-end.
 - "Max retries exceeded with url" for CRX samples
 - upsetplot segfault due to interactive matplotlib backend
+- DESeq2 error: "EOF within quoted string"
 - conda environment channel priorities 
 
 ## [0.9.8] - 2023-02-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - cyclic dependency on rule samtools_sort (caused by tildes in config paths)
 - bug in DESeq2 related rules when using custom assemblies
 - clear error message when downloading single-end data annotated as paired-end.
+- "Max retries exceeded with url" for CRX samples
 
 ## [0.9.8] - 2023-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - bug in DESeq2 related rules when using custom assemblies
 - clear error message when downloading single-end data annotated as paired-end.
 - "Max retries exceeded with url" for CRX samples
+- upsetplot segfault due to interactive matplotlib backend
 - conda environment channel priorities 
 
 ## [0.9.8] - 2023-02-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 - moved downloading fastqs to localrules
 - bam indexes are kept (not automatically removed)
-- Salmon updated to the latest version v1.10.1
+- Salmon updated to the latest version v1.10.1 (fixes a bug)
+- upsetplot updated to the latest version (fixes a bug)
+- genomepy updated to the latest version (no reason)
+- tabulate updated to the latest version (longer python support)
 - `--snakemakeOption debug_dag=True` can now be used with 1 core (required)
 - creating conda environments now faster
   - updated conda & mamba
@@ -27,6 +30,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - bug in DESeq2 related rules when using custom assemblies
 - clear error message when downloading single-end data annotated as paired-end.
 - "Max retries exceeded with url" for CRX samples
+- conda environment channel priorities 
 
 ## [0.9.8] - 2023-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - bam indexes are kept (not automatically removed)
 - Salmon updated to the latest version v1.10.1
 - `--snakemakeOption debug_dag=True` can now be used with 1 core (required)
+- creating conda environments now faster
+  - updated conda & mamba
+  - dropped indexing of Conda's defaults channel
 
 ### Fixed
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -2,13 +2,12 @@ name: s2s
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - conda-forge::python=3.8
-  - bioconda::snakemake-minimal=7.18.2
-  - conda-forge::conda=4.11.0
-  - conda-forge::mamba=0.20.0
-  - bioconda::genomepy=0.13.0
+  - bioconda::snakemake-minimal=7.25.0
+  - conda-forge::conda=23.1.0
+  - conda-forge::mamba=1.2.0
+  - bioconda::genomepy=0.15.0
   - conda-forge::biopython=1.79
   - conda-forge::filelock=3.7.1
   - conda-forge::pyyaml=6.0
@@ -19,5 +18,5 @@ dependencies:
   - conda-forge::matplotlib=3.5.2
   - conda-forge::xdg=5.1.1
   - conda-forge::argcomplete=2.0.0
-  - conda-forge::tabulate=0.8.9
+  - conda-forge::tabulate=0.9.0
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/assembly_stats.yaml
+++ b/seq2science/envs/assembly_stats.yaml
@@ -2,10 +2,9 @@ name: assembly_stats
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - defaults::python=3.7
+  - conda-forge::python=3.7
   - bioconda::pyfaidx=0.6.3.1
   - conda-forge::matplotlib=3.4.3
-  - bioconda::genomepy=0.10.0
+  - bioconda::genomepy=0.15.0
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/assembly_stats.yaml
+++ b/seq2science/envs/assembly_stats.yaml
@@ -4,7 +4,6 @@ channels:
   - bioconda
 dependencies:
   - conda-forge::python=3.7
-  - bioconda::pyfaidx=0.6.3.1
   - conda-forge::matplotlib=3.4.3
   - bioconda::genomepy=0.15.0
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/bedtools.yaml
+++ b/seq2science/envs/bedtools.yaml
@@ -2,7 +2,6 @@ name: bedtools
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::bedtools=2.29.2
   - conda-forge::coreutils=9.1

--- a/seq2science/envs/bowtie2.yaml
+++ b/seq2science/envs/bowtie2.yaml
@@ -2,7 +2,6 @@ name: bowtie2
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::bowtie2=2.4.2
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/bwa.yaml
+++ b/seq2science/envs/bwa.yaml
@@ -2,7 +2,6 @@ name: bwa
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::bwa=0.7.17
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/bwamem2.yaml
+++ b/seq2science/envs/bwamem2.yaml
@@ -2,7 +2,6 @@ name: bwamem2
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::bwa-mem2=2.2.1
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/chipseeker.yaml
+++ b/seq2science/envs/chipseeker.yaml
@@ -2,10 +2,9 @@ name: chipseeker
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - r-base=3.6.3
-  - bioconductor-chipseeker
-  - bioconductor-do.db
-  - bioconductor-genomicfeatures
+  - conda-forge::r-base=3.6.3
+  - bioconda::bioconductor-chipseeker
+  - bioconda::bioconductor-do.db
+  - bioconda::bioconductor-genomicfeatures
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/cite-seq-count.yaml
+++ b/seq2science/envs/cite-seq-count.yaml
@@ -2,7 +2,6 @@ name: cite-seq-count
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies: 
   - bioconda::cite-seq-count=1.4.4
   - conda-forge::python-levenshtein=0.12.0

--- a/seq2science/envs/decoy.yaml
+++ b/seq2science/envs/decoy.yaml
@@ -2,7 +2,6 @@ name: decoy
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::bedtools=2.29.2
   - bioconda::mashmap=2.0

--- a/seq2science/envs/deeptools.yaml
+++ b/seq2science/envs/deeptools.yaml
@@ -2,7 +2,6 @@ name: deeptools
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::deeptools=3.5.1
   - conda-forge::matplotlib-base=3.5.3

--- a/seq2science/envs/deseq2.yaml
+++ b/seq2science/envs/deseq2.yaml
@@ -2,7 +2,6 @@ name: deseq2
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - conda-forge::r-base=4.1  # R hotfix version isn't pinned for libraries
   - bioconda::bioconductor-deseq2=1.34

--- a/seq2science/envs/dexseq.yaml
+++ b/seq2science/envs/dexseq.yaml
@@ -2,7 +2,6 @@ name: dexseq
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::bioconductor-dexseq=1.32.0
   - bioconda::pysam=0.16.0.1

--- a/seq2science/envs/dupradar.yaml
+++ b/seq2science/envs/dupradar.yaml
@@ -2,7 +2,6 @@ name: dupradar
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - conda-forge::r-base=4.0.3
   - bioconda::bioconductor-dupradar=1.20.0

--- a/seq2science/envs/edger.yaml
+++ b/seq2science/envs/edger.yaml
@@ -2,7 +2,6 @@ name: edger
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::bioconductor-edger=3.28.0
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/fastp.yaml
+++ b/seq2science/envs/fastp.yaml
@@ -2,7 +2,6 @@ name: fastp
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::fastp=0.20.1
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/fastq-pair.yaml
+++ b/seq2science/envs/fastq-pair.yaml
@@ -2,7 +2,6 @@ name: fastq-pair
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::fastq-pair=1.0
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/fastqc.yaml
+++ b/seq2science/envs/fastqc.yaml
@@ -2,7 +2,6 @@ name: fastqc
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::fastqc=0.11.8
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/gene_counts.yaml
+++ b/seq2science/envs/gene_counts.yaml
@@ -2,7 +2,6 @@ name: gene_counts
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::htseq=0.12.4
   - bioconda::subread=2.0.1

--- a/seq2science/envs/genrich.yaml
+++ b/seq2science/envs/genrich.yaml
@@ -2,7 +2,6 @@ name: genrich
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::genrich=0.6.1
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/gimme.yaml
+++ b/seq2science/envs/gimme.yaml
@@ -2,7 +2,6 @@ name: gimme
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::gimmemotifs-minimal=0.17.2
   - bioconda::gffread=0.12.7

--- a/seq2science/envs/hisat2.yaml
+++ b/seq2science/envs/hisat2.yaml
@@ -2,7 +2,6 @@ name: hisat2
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::hisat2=2.2.1
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/hmmratac.yaml
+++ b/seq2science/envs/hmmratac.yaml
@@ -2,7 +2,6 @@ name: hmmratac
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::hmmratac=1.2.5
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/htmltable.yaml
+++ b/seq2science/envs/htmltable.yaml
@@ -1,8 +1,6 @@
 name: htmltable
 channels:
   - conda-forge
-  - bioconda
-  - defaults
 dependencies:
   - conda-forge::pretty_html_table=0.9.11
   - conda-forge::pandas=1.3.2

--- a/seq2science/envs/idr.yaml
+++ b/seq2science/envs/idr.yaml
@@ -2,7 +2,6 @@ name: idr
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::idr=2.0.4.2
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/imagemick.yaml
+++ b/seq2science/envs/imagemick.yaml
@@ -1,8 +1,6 @@
 name: imagemick
 channels:
   - conda-forge
-  - bioconda
-  - defaults
 dependencies:
   - conda-forge::imagemagick>=7.0
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/kallistobus.yaml
+++ b/seq2science/envs/kallistobus.yaml
@@ -2,9 +2,8 @@ name: kallistobus
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - python>=3.7
+  - conda-forge::python=3.8
   - bioconda::kb-python=0.27.3
   - conda-forge::numpy=1.21.5
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/khmer.yaml
+++ b/seq2science/envs/khmer.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::khmer=2.0
+  - bioconda::khmer=3.0
   - conda-forge::jq=1.6
   - conda-forge::grep=3.10
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/khmer.yaml
+++ b/seq2science/envs/khmer.yaml
@@ -2,7 +2,6 @@ name: khmer
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::khmer=2.0
   - conda-forge::jq=1.6

--- a/seq2science/envs/khmer.yaml
+++ b/seq2science/envs/khmer.yaml
@@ -5,5 +5,5 @@ channels:
 dependencies:
   - bioconda::khmer=2.0
   - conda-forge::jq=1.6
-  - bioconda::grep=3.4
+  - conda-forge::grep=3.10
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/macs2.yaml
+++ b/seq2science/envs/macs2.yaml
@@ -2,7 +2,6 @@ name: macs2
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::macs2=2.2.7
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/minimap2.yaml
+++ b/seq2science/envs/minimap2.yaml
@@ -2,7 +2,6 @@ name: minimap2
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::minimap2=2.17
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/mtnucratio.yaml
+++ b/seq2science/envs/mtnucratio.yaml
@@ -2,7 +2,6 @@ name: picard
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::mtnucratio=0.7
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/multiqc.yaml
+++ b/seq2science/envs/multiqc.yaml
@@ -2,7 +2,6 @@ name: multiqc
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::multiqc=1.14
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/picard.yaml
+++ b/seq2science/envs/picard.yaml
@@ -2,7 +2,6 @@ name: picard
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::picard=2.23.8
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/pysam.yaml
+++ b/seq2science/envs/pysam.yaml
@@ -2,7 +2,6 @@ name: pysam
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::pysam=0.15.3
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/pytxi.yaml
+++ b/seq2science/envs/pytxi.yaml
@@ -2,9 +2,8 @@ name: pytxi
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - bioconda::genomepy=0.12.0
+  - bioconda::genomepy=0.15.0
   - conda-forge::conda-ecosystem-user-package-isolation=1.0
   - pip:
     - git+https://github.com/vanheeringen-lab/pytxi.git@v0.1.2

--- a/seq2science/envs/qnorm.yaml
+++ b/seq2science/envs/qnorm.yaml
@@ -1,8 +1,6 @@
 name: qnorm
 channels:
   - conda-forge
-  - bioconda
-  - defaults
 dependencies:
   - conda-forge::qnorm=0.4.0
   - conda-forge::pandas=1.1.2

--- a/seq2science/envs/salmon.yaml
+++ b/seq2science/envs/salmon.yaml
@@ -2,7 +2,6 @@ name: salmon
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::salmon=1.10.1
   - bioconda::gffread=0.12.7

--- a/seq2science/envs/sambamba.yaml
+++ b/seq2science/envs/sambamba.yaml
@@ -2,7 +2,6 @@ name: sambamba
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::sambamba=0.7.0
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/samtools.yaml
+++ b/seq2science/envs/samtools.yaml
@@ -2,7 +2,6 @@ name: samtools
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::samtools=1.14
   - conda-forge::perl=5.32.1

--- a/seq2science/envs/sce.yaml
+++ b/seq2science/envs/sce.yaml
@@ -2,7 +2,6 @@ name: sce
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::bioconductor-singlecelltk=2.4.0
   - conda-forge::r-matrix=1.5_1

--- a/seq2science/envs/sctk.yaml
+++ b/seq2science/envs/sctk.yaml
@@ -2,7 +2,6 @@ name: sctk
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::bioconductor-singlecelltk=2.4.0
   - bioconda::bbknn=1.5.1

--- a/seq2science/envs/snaptools.yaml
+++ b/seq2science/envs/snaptools.yaml
@@ -2,7 +2,6 @@ name: snaptools
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::snaptools=1.4.8
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/star.yaml
+++ b/seq2science/envs/star.yaml
@@ -2,7 +2,6 @@ name: star
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::star=2.7.6a
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/subread.yaml
+++ b/seq2science/envs/subread.yaml
@@ -2,7 +2,6 @@ name: subread
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::subread=1.6.4
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/trimgalore.yaml
+++ b/seq2science/envs/trimgalore.yaml
@@ -2,7 +2,6 @@ name: trimgalore
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::trim-galore=0.6.4
   - conda-forge::cpulimit=0.2

--- a/seq2science/envs/tximeta.yaml
+++ b/seq2science/envs/tximeta.yaml
@@ -1,12 +1,10 @@
 name: tximeta
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
 dependencies:
-  # linked_txome & txi count table
   - conda-forge::r-base=4.1.1
-  - bioconda::bioconductor-tximeta=1.10.0  # 1.8.0 is bugged, >=1.8.3 should be fixed again
-  # txi counts table
+  - bioconda::bioconductor-tximeta=1.10.0
   - bioconda::bioconductor-singlecellexperiment=1.14.1
   - conda-forge::r-tidyverse=1.3.1
   - conda-forge::r-readr=1.4.0

--- a/seq2science/envs/tximeta.yaml
+++ b/seq2science/envs/tximeta.yaml
@@ -2,7 +2,6 @@ name: tximeta
 channels:
   - bioconda
   - conda-forge
-  - defaults
 dependencies:
   # linked_txome & txi count table
   - conda-forge::r-base=4.1.1

--- a/seq2science/envs/ucsc.yaml
+++ b/seq2science/envs/ucsc.yaml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::grep=3.4
   - bioconda::ucsc-bedsort=377
   - bioconda::ucsc-bedGraphToBigWig=377
   - bioconda::ucsc-bedToBigBed=377
@@ -13,4 +12,5 @@ dependencies:
   - bioconda::ucsc-hggcpercent=377
   - bioconda::ucsc-ixixx=377
   - bioconda::ucsc-wigtobigwig=377
+  - conda-forge::grep=3.10
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/ucsc.yaml
+++ b/seq2science/envs/ucsc.yaml
@@ -2,7 +2,6 @@ name: ucsc
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::grep=3.4
   - bioconda::ucsc-bedsort=377

--- a/seq2science/envs/upset.yaml
+++ b/seq2science/envs/upset.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
 dependencies:
   - conda-forge::upsetplot=0.8.0
-  - conda-forge::matplotlib-base=3.5.3
+  - conda-forge::matplotlib-base=3.7.1
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/upset.yaml
+++ b/seq2science/envs/upset.yaml
@@ -2,6 +2,6 @@ name: upset
 channels:
   - conda-forge
 dependencies:
-  - conda-forge::upsetplot=0.6.0
+  - conda-forge::upsetplot=0.8.0
   - conda-forge::matplotlib-base=3.5.3
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/envs/upset.yaml
+++ b/seq2science/envs/upset.yaml
@@ -1,8 +1,6 @@
 name: upset
 channels:
   - conda-forge
-  - bioconda
-  - defaults
 dependencies:
   - conda-forge::upsetplot=0.6.0
   - conda-forge::matplotlib-base=3.5.3

--- a/seq2science/rules/qc_peaks.smk
+++ b/seq2science/rules/qc_peaks.smk
@@ -120,6 +120,8 @@ rule upset_plot_peaks:
         expand("{counts_dir}/{{peak_caller}}/{{assembly}}_onehotpeaks.tsv", **config)
     output:
         expand("{qc_dir}/upset/{{assembly}}-{{peak_caller}}_upset_mqc.jpg", **config)
+    log:
+        expand("{log_dir}/upset/{{assembly}}-{{peak_caller}}.log", **config),
     conda:
         "../envs/upset.yaml"
     script:

--- a/seq2science/rules/qc_peaks.smk
+++ b/seq2science/rules/qc_peaks.smk
@@ -120,8 +120,6 @@ rule upset_plot_peaks:
         expand("{counts_dir}/{{peak_caller}}/{{assembly}}_onehotpeaks.tsv", **config)
     output:
         expand("{qc_dir}/upset/{{assembly}}-{{peak_caller}}_upset_mqc.jpg", **config)
-    log:
-        expand("{log_dir}/upset/{{assembly}}-{{peak_caller}}.log", **config),
     conda:
         "../envs/upset.yaml"
     script:

--- a/seq2science/scripts/assembly_stats.py
+++ b/seq2science/scripts/assembly_stats.py
@@ -3,7 +3,6 @@ import base64
 from collections import Counter
 from itertools import accumulate
 
-import pyfaidx
 import matplotlib.pyplot as plt
 import genomepy
 
@@ -15,7 +14,7 @@ assembly = snakemake.wildcards.assembly
 open(outfile, "w").close()
 
 # read the assembly
-fa = pyfaidx.Fasta(snakemake.input.genome)
+fa = genomepy.Genome(snakemake.input.genome)
 
 # variables to keep track of
 gc = at = 0

--- a/seq2science/scripts/deseq2/clustering.R
+++ b/seq2science/scripts/deseq2/clustering.R
@@ -44,8 +44,8 @@ coldata  <- samples[cols]
 coldata['assembly'] <- factor(as.character(seq_len(nrow(coldata))))
 
 # filter counts to speed up DESeq
-counts <- read.table(counts_file, row.names = 1, header = T, stringsAsFactors = F, sep = '\t', check.names = F)
-reduced_counts <- counts[rowSums(counts) > 0, rownames(coldata)]
+counts <- read.table(counts_file, row.names = 1, header = T, stringsAsFactors = F, sep = '\t', quote= "", check.names = F)
+reduced_counts <- counts[rowSums(counts) > 0, ]
 
 
 ## DESeq2

--- a/seq2science/scripts/deseq2/clustering.R
+++ b/seq2science/scripts/deseq2/clustering.R
@@ -45,7 +45,7 @@ coldata['assembly'] <- factor(as.character(seq_len(nrow(coldata))))
 
 # filter counts to speed up DESeq
 counts <- read.table(counts_file, row.names = 1, header = T, stringsAsFactors = F, sep = '\t', quote= "", check.names = F)
-reduced_counts <- counts[rowSums(counts) > 0, ]
+reduced_counts <- counts[rowSums(counts) > 0, rownames(coldata)]
 
 
 ## DESeq2

--- a/seq2science/scripts/deseq2/deseq2.R
+++ b/seq2science/scripts/deseq2/deseq2.R
@@ -66,8 +66,8 @@ coldata$batch     <- factor(coldata$batch)
 
 
 ## filter counts to speed up DESeq
-counts <- read.table(counts_file, row.names = 1, header = T, stringsAsFactors = F, sep = '\t', check.names = F)
-reduced_counts <- counts[rowSums(counts) > 0, rownames(coldata)]
+counts <- read.table(counts_file, row.names = 1, header = T, stringsAsFactors = F, sep = '\t', quote= "", check.names = F)
+reduced_counts <- counts[rowSums(counts) > 0, ]
 
 ## DESeq2
 design <- if (!is.na(batch)){~ batch + condition} else {~ condition}

--- a/seq2science/scripts/deseq2/deseq2.R
+++ b/seq2science/scripts/deseq2/deseq2.R
@@ -67,7 +67,7 @@ coldata$batch     <- factor(coldata$batch)
 
 ## filter counts to speed up DESeq
 counts <- read.table(counts_file, row.names = 1, header = T, stringsAsFactors = F, sep = '\t', quote= "", check.names = F)
-reduced_counts <- counts[rowSums(counts) > 0, ]
+reduced_counts <- counts[rowSums(counts) > 0, rownames(coldata)]
 
 ## DESeq2
 design <- if (!is.na(batch)){~ batch + condition} else {~ condition}

--- a/seq2science/scripts/deseq2/utils.R
+++ b/seq2science/scripts/deseq2/utils.R
@@ -225,7 +225,7 @@ heatmap_aesthetics <- function(num_samples){
   } else {
     cell_dimensions <- 5  # minimal size
     fontsize        <- 3.2
-    fontsize_number <- 2.5
+    fontsize_number <- 0  # 2.5
   }
   show_colnames <- ifelse(num_samples > 28, TRUE, FALSE)
   show_rownames <- !show_colnames

--- a/seq2science/scripts/upset.py
+++ b/seq2science/scripts/upset.py
@@ -13,7 +13,7 @@ df = df > 0
 data = dict()
 for col in df.columns:
     row = list()
-    for index, val in df[col].iteritems():
+    for index, val in df[col].items():
         if val:
             row.append(index)
     data[col] = row

--- a/seq2science/scripts/upset.py
+++ b/seq2science/scripts/upset.py
@@ -1,37 +1,40 @@
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+from contextlib import redirect_stdout, redirect_stderr
 from upsetplot import from_contents, from_memberships, from_indicators, plot
 
 
-# read the table
-df = pd.read_table(snakemake.input[0], comment="#", index_col=0)
-df = df.drop(":-")
-df = df > 0
+with open(str(snakemake.log), "w") as f:
+    with redirect_stdout(f), redirect_stderr(f):
 
-# put it in a dictionary
-data = dict()
-for col in df.columns:
-    row = list()
-    for index, val in df[col].items():
-        if val:
-            row.append(index)
-    data[col] = row
+        # read the table
+        df = pd.read_table(snakemake.input[0], comment="#", index_col=0)
+        df = df.drop(":-")
+        df = df > 0
 
+        # put it in a dictionary
+        data = dict()
+        for col in df.columns:
+            row = list()
+            for index, val in df[col].items():
+                if val:
+                    row.append(index)
+            data[col] = row
 
-f, ax = plt.subplots()
-ax.axis("off")
+        f, ax = plt.subplots()
+        ax.axis("off")
 
-# generate the upset plot
-# but make sure to filter to a max of 31 combinations
-# 31 is the maximum of combinations of 5 different items
-content = from_contents(data)
-uniques, counts = np.unique(content.index, return_counts=True)
+        # generate the upset plot
+        # but make sure to filter to a max of 31 combinations
+        # 31 is the maximum of combinations of 5 different items
+        content = from_contents(data)
+        uniques, counts = np.unique(content.index, return_counts=True)
 
-sorted_uniques = [x for _, x in sorted(zip(counts, uniques), reverse=True)]
+        sorted_uniques = [x for _, x in sorted(zip(counts, uniques), reverse=True)]
 
-plot(content.loc[sorted_uniques[:31]], sort_by=None)
+        plot(content.loc[sorted_uniques[:31]], sort_by=None)
 
-upsetplot = plot(from_contents(data), fig=f)
+        upsetplot = plot(from_contents(data), fig=f)
 
-plt.savefig(snakemake.output[0], dpi=250)
+        plt.savefig(snakemake.output[0], dpi=250)

--- a/seq2science/scripts/upset.py
+++ b/seq2science/scripts/upset.py
@@ -1,40 +1,40 @@
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
-from contextlib import redirect_stdout, redirect_stderr
 from upsetplot import from_contents, from_memberships, from_indicators, plot
+import matplotlib.pyplot as plt
 
 
-with open(str(snakemake.log), "w") as f:
-    with redirect_stdout(f), redirect_stderr(f):
+# any non-interactive backend prevents segfaults
+# docs: https://matplotlib.org/stable/users/explain/backends.html
+plt.switch_backend('Agg')
 
-        # read the table
-        df = pd.read_table(snakemake.input[0], comment="#", index_col=0)
-        df = df.drop(":-")
-        df = df > 0
+# read the table
+df = pd.read_table(snakemake.input[0], comment="#", index_col=0)
+df = df.drop(":-")
+df = df > 0
 
-        # put it in a dictionary
-        data = dict()
-        for col in df.columns:
-            row = list()
-            for index, val in df[col].items():
-                if val:
-                    row.append(index)
-            data[col] = row
+# put it in a dictionary
+data = dict()
+for col in df.columns:
+    row = list()
+    for index, val in df[col].items():
+        if val:
+            row.append(index)
+    data[col] = row
 
-        f, ax = plt.subplots()
-        ax.axis("off")
+f, ax = plt.subplots()
+ax.axis("off")
 
-        # generate the upset plot
-        # but make sure to filter to a max of 31 combinations
-        # 31 is the maximum of combinations of 5 different items
-        content = from_contents(data)
-        uniques, counts = np.unique(content.index, return_counts=True)
+# generate the upset plot
+# but make sure to filter to a max of 31 combinations
+# 31 is the maximum of combinations of 5 different items
+content = from_contents(data)
+uniques, counts = np.unique(content.index, return_counts=True)
 
-        sorted_uniques = [x for _, x in sorted(zip(counts, uniques), reverse=True)]
+sorted_uniques = [x for _, x in sorted(zip(counts, uniques), reverse=True)]
 
-        plot(content.loc[sorted_uniques[:31]], sort_by=None)
+plot(content.loc[sorted_uniques[:31]], sort_by=None)
 
-        upsetplot = plot(from_contents(data), fig=f)
+upsetplot = plot(from_contents(data), fig=f)
 
-        plt.savefig(snakemake.output[0], dpi=250)
+plt.savefig(snakemake.output[0], dpi=250)

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -158,6 +158,7 @@ def crx2downloads(crx_id):
     # get from the crx number the accession number and the experiment url
     url = f"https://ngdc.cncb.ac.cn/search/?dbId=gsa&q={crx_id}"
     r = requests.get(url)
+    time.sleep(0.1)
     if r.status_code != 200:
         return {}
 
@@ -169,6 +170,7 @@ def crx2downloads(crx_id):
 
     # then get the run id and url from the experiment number page
     r = requests.get(crx_url)
+    time.sleep(0.1)
     if r.status_code != 200:
         return {}
 
@@ -183,6 +185,7 @@ def crx2downloads(crx_id):
 
         # finally find the download links that belong to the run
         r = requests.get(crr_url)
+        time.sleep(0.1)
         if r.status_code != 200:
             return []
 
@@ -236,6 +239,7 @@ def samples2metadata_gsa(samples: List[str], logger) -> dict:
         os._exit(1)  # noqa
 
     return sampledict
+
 
 def samples2metadata_sra(samples: List[str], logger) -> dict:
     """

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -944,6 +944,8 @@ def _get_current_version(package):
         package = "yaml"
     elif package == "biopython":
         package = "Bio"
+    elif package == "matplotlib-base":
+        package = "matplotlib"
 
     ldict = dict()
     exec(f"from {package} import __version__", {}, ldict)

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -41,7 +41,8 @@ pipeline {
                 printf "\ndownload miniconda\n"
                 PY=$(grep conda-forge::python= requirements.yaml | tr -d -c 0-9)
                 CO=$(grep conda-forge::conda= requirements.yaml | cut -d '=' -f2)
-                wget https://repo.anaconda.com/miniconda/Miniconda3-py${PY}_${CO}-Linux-x86_64.sh -nv -O miniconda.sh
+                URL=https://repo.anaconda.com/miniconda/Miniconda3-py${PY}_${CO}-1-Linux-x86_64.sh
+                wget $URL -nv -O miniconda.sh
 
                 printf "\ninstall miniconda\n"
                 bash miniconda.sh -b -p $WORKSPACE/miniconda > /dev/null 2>&1
@@ -52,8 +53,8 @@ pipeline {
                 conda config --set channel_priority strict
                 
                 printf "\ninstall mamba\n"
-                VERSION=$(cat requirements.yaml | grep mamba | cut -d '=' -f2)
-                conda install -c conda-forge conda=$CO mamba=$VERSION
+                MA=$(cat requirements.yaml | grep mamba | cut -d '=' -f2)
+                conda install -c conda-forge conda=$CO mamba=$MA
 
                 printf "\ninstalling seq2science environment\n"
                 mamba env create -f requirements.yaml


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
speed up conda by:
- using the latest compatible versions of conda & mamba
- dropping the usage of the `defaults` conda repo
- using the latest snakemake

Some other packages have been updated as well, mostly to bypass Conda channel priority errors. Exceptions: tabulate (supports newer python versions), genomepy (same version everywhere now) and matplotlib (using matplotlib-base now)

Also included: a rough fix for CRX request rate limit (`time.sleep(0.1)`), which is not 100% effective, but is a big improvement.

**Checklist**
- [x] I made a PR to develop (not master)
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
