### PR TITLE
improve deseq2 clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 - one less global variable! (sanitized_samples)
 - dropped correlation scores from DESeq2 clusterplots
   - pheatmap is too finickey to get the fontsize right
+- pheatmap uses the sample order (from the samples.tsv) as best as possible 
 
 ### Fixed
 

--- a/seq2science/envs/deseq2.yaml
+++ b/seq2science/envs/deseq2.yaml
@@ -18,4 +18,5 @@ dependencies:
   - conda-forge::r-pheatmap=1.0.12
   - conda-forge::r-pdftools=3.1
   - conda-forge::r-gridextra=2.3
+  - conda-forge::r-dendextend=1.17
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/scripts/deseq2/utils.R
+++ b/seq2science/scripts/deseq2/utils.R
@@ -255,8 +255,15 @@ heatmap_names <- function(mat, coldata) {
 
 
 heatmap_plot <- function(mat, title, heatmap_aes, legend_aes, out_pdf) {
+  #' rotate the dendogram to best match the order in the samples.tsv
+  callback <- function(hc, mat){
+    hc <- dendextend::rotate(hc, order=colnames(mat))
+    return(hc)
+  }
+
   pheatmap::pheatmap(
     mat,
+    clustering_callback = callback,
     main = title,
     angle_col = 45,
     show_colnames = heatmap_aes$show_colnames,  # show names underneath if the image gets to wide


### PR DESCRIPTION
Rotate the samples to (try to) match the order given by the samples.tsv. In the example below, my samples.tsv was sorted chronologically. From stage 13, samples can't follow the samples.tsv order anymore, but try to as much as possible.

**before**
![image](https://user-images.githubusercontent.com/48289046/232811139-5a1c108e-30d3-450b-bd11-61a91c29dd4b.png)

**after**
![image](https://user-images.githubusercontent.com/48289046/232811623-df2a87f8-a796-4a16-b0c1-3cda27a55d96.png)


**Checklist**
- [x] I made a PR to develop (not master)
- [x] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
