### PR TITLE
gimme maelstrom without XDG_CACHE_DIR set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 - DESeq2 should no longer crash without DE genes
 - bug with single-ended reads and subread
+- gimme maelstrom dependency missing
+- gimme maelstrom bug when XDG_CACHE_DIR is not set
 
 ## [0.9.9] - 2023-04-21
 

--- a/seq2science/envs/gimme.yaml
+++ b/seq2science/envs/gimme.yaml
@@ -6,5 +6,6 @@ dependencies:
   - bioconda::gimmemotifs-minimal=0.18.0
   - bioconda::gffread=0.12.7
   - bioconda::orthofinder=2.5.4
+  - conda-forge::xgboost=1.0.2
   - conda-forge::cpulimit=0.2
   - conda-forge::conda-ecosystem-user-package-isolation=1.0

--- a/seq2science/rules/motif_scan.smk
+++ b/seq2science/rules/motif_scan.smk
@@ -66,10 +66,10 @@ rule gimme_maelstrom:
         """
         NEW_CACHE={output.cache}
         mkdir -p $NEW_CACHE
-        if [ -z $XDG_CACHE_HOME ]; then
-            XDG_CACHE_HOME=$HOME/.cache
+        if [ -z ${{XDG_CACHE_HOME+x}} ]; then
+            export XDG_CACHE_HOME=$HOME/.cache
         fi
-        if [ -d $XDG_CACHE_HOME/gimmemotifs ]; then 
+        if [ -d $XDG_CACHE_HOME/gimmemotifs ]; then
             cp -r $XDG_CACHE_HOME/gimmemotifs $NEW_CACHE/
         fi
         export XDG_CACHE_HOME=$NEW_CACHE
@@ -78,3 +78,4 @@ rule gimme_maelstrom:
         """
         gimme maelstrom {input.count_table} {input.genome} {output.output} --pfmfile {params.pfmfile} --nthreads {threads} {params.params} > {log} 2>&1
         """
+


### PR DESCRIPTION
**What problem is the PR solving / What's new?**

gimme maelstrom needs dependency that was removed with latest update and if cache not set it didnt work the previous implementation 👼 

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [ ] These changes are covered by the tests
