### PR TITLE
Update deseq2.R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 - sctk yaml simplified
 
+### Fixed
+
+- DESeq2 should no longer crash without DE genes
+
 ## [0.9.9] - 2023-04-21
 
 ### Changed

--- a/seq2science/scripts/deseq2/deseq2.R
+++ b/seq2science/scripts/deseq2/deseq2.R
@@ -101,7 +101,6 @@ cat('DE genes table saved\n\n')
 n_DEGs <- length(resLFC[resLFC$padj <= fdr & !is.na(resLFC$padj), ][,1])
 if (n_DEGs == 0) {
   cat("No differentially expressed genes found!\n")
-  quit(save = "no" , status = 0)
 } else {
   cat(n_DEGs, "differentially expressed genes found!\n")
 }


### PR DESCRIPTION
**What problem is the PR solving / What's new?**
Fixed the crash in DESeq2 when no differential genes were detected.

**What did change**
It seems R has been updated to handle generating these plots, even when no differential genes are detected.

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [ ] I updated the CHANGELOG
- [ ] These changes are covered by the tests
