### PR TITLE
Update util.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ## [Unreleased]
 
+### Fixed
+
+- issue with printing a nice traceback when the SRA is unresponsive
+
 ## [1.0.2] - 2023-07-14
 
 ### Fixed

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -306,7 +306,7 @@ def samples2metadata_sra(samples: List[str], logger) -> dict:
             "seq2science does not support downloading those..\n\n"
         )
         logger.debug(f"Affected samples: {', '.join(sample2clean.values())}")
-        tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+        tb_str = traceback.format_exception(value=e, tb=e.__traceback__)
         logger.debug("".join(tb_str))
         os._exit(1)  # noqa
 

--- a/seq2science/util.py
+++ b/seq2science/util.py
@@ -284,7 +284,7 @@ def samples2metadata_sra(samples: List[str], logger) -> dict:
                 "seq2science does not support downloading those..\n\n"
             )
             logger.debug(f"Affected samples: {', '.join(geo_samples)}")
-            tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+            tb_str = traceback.format_exception(value=e, tb=e.__traceback__)
             logger.debug("".join(tb_str))
             os._exit(1)  # noqa
 


### PR DESCRIPTION
**What problem is the PR solving / What's new?**

>Changed in version 3.5: The etype argument is ignored and inferred from the type of value.

Crashes now. So I guess removing it solves the problem...??

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [ ] These changes are covered by the tests
