### PR TITLE
fix issue when colors in table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All changed fall under either one of these types: `Added`, `Changed`, `Deprecate
 
 ## [Unreleased]
 
+### Fixed
+
+- issue when specifying colors in the samples table and the QC report not rendering the table correctly anymore.
+
 ## [1.0.4] - 2023-09-05
 
 ### Changed

--- a/seq2science/scripts/multiqc_samplesconfig.py
+++ b/seq2science/scripts/multiqc_samplesconfig.py
@@ -12,7 +12,8 @@ outstring = \
     "section_name: 'Samples & Config'\n" \
     "-->\n"
 
-samples = pd.read_table(StringIO(snakemake.params.samples), sep="\s+")
+# the separator is two spaces (or more)
+samples = pd.read_table(StringIO(snakemake.params.samples), sep="\s{2,}")
 outstring += "The samples file used for this run: <br>" \
              f"{build_table(samples, 'blue_dark')}"
 


### PR DESCRIPTION
**What problem is the PR solving / What's new?**

Colors get spaces in them as a tuple (12, 42, 32) so the qc report table gets fked :smile: . By specifying that a column has AT LEAST two spaces we circument this problem.

**Checklist**
- [x] I made a PR to develop (not master)
- [ ] If applicable: I updated the docs
- [x] I updated the CHANGELOG
- [x] These changes are covered by the tests
